### PR TITLE
Tab titles display

### DIFF
--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthScreen.kt
@@ -27,8 +27,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import edu.stanford.bdh.engagehf.R
 import edu.stanford.bdh.engagehf.health.bloodpressure.BloodPressurePage
 import edu.stanford.bdh.engagehf.health.heartrate.HeartRatePage
 import edu.stanford.bdh.engagehf.health.symptoms.SymptomsPage
@@ -114,10 +116,10 @@ private fun HealthTabRow(
                 text = {
                     Text(
                         text = when (tab) {
-                            HealthTab.Symptoms -> "Symptoms"
-                            HealthTab.Weight -> "Weight"
-                            HealthTab.BloodPressure -> "Blood Pressure"
-                            HealthTab.HeartRate -> "Heart Rate"
+                            HealthTab.Symptoms -> stringResource(R.string.health_tab_title_symptoms)
+                            HealthTab.Weight -> stringResource(R.string.health_tab_title_weight)
+                            HealthTab.BloodPressure -> stringResource(R.string.health_tab_title_blood_pressure)
+                            HealthTab.HeartRate -> stringResource(R.string.health_tab_title_heart_rate)
                         },
                     )
                 },

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthScreen.kt
@@ -73,6 +73,7 @@ fun HealthScreen(
             HealthTabRow(uiState = uiState, onAction = onAction)
             HorizontalPager(
                 state = pagerState,
+                userScrollEnabled = false,
                 modifier = Modifier
                     .weight(1f)
                     .padding(horizontal = Spacings.medium)

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
@@ -91,9 +91,18 @@ class HealthUiStateMapper @Inject constructor(
         val groupedRecords = groupRecordsByTimeRange(records, selectedTimeRange)
         return groupedRecords.values.map { entries ->
             val averageValue = entries.map { getValue(it, diastolic).value }.average()
-            val xValue =
-                entries.first().zonedDateTime.toEpochSecond().toFloat() / EPOCH_SECONDS_DIVISOR
-            Pair(averageValue.toFloat(), xValue)
+            Pair(
+                averageValue.toFloat(),
+                mapXValue(selectedTimeRange, entries.first().zonedDateTime)
+            )
+        }
+    }
+
+    private fun mapXValue(selectedTimeRange: TimeRange, zonedDateTime: ZonedDateTime): Float {
+        return when (selectedTimeRange) {
+            TimeRange.DAILY -> zonedDateTime.dayOfYear.toFloat()
+            TimeRange.WEEKLY -> (zonedDateTime.dayOfYear / 7).toFloat()
+            TimeRange.MONTHLY -> zonedDateTime.monthValue.toFloat()
         }
     }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
@@ -91,7 +91,8 @@ class HealthUiStateMapper @Inject constructor(
         val groupedRecords = groupRecordsByTimeRange(records, selectedTimeRange)
         return groupedRecords.values.map { entries ->
             val averageValue = entries.map { getValue(it, diastolic).value }.average()
-            val xValue = entries.first().zonedDateTime.toEpochSecond().toFloat() / EPOCH_SECONDS_DIVISOR
+            val xValue =
+                entries.first().zonedDateTime.toEpochSecond().toFloat() / EPOCH_SECONDS_DIVISOR
             Pair(averageValue.toFloat(), xValue)
         }
     }
@@ -178,7 +179,7 @@ class HealthUiStateMapper @Inject constructor(
 
     private fun getMaxMonths(selectedTimeRange: TimeRange): Long {
         return when (selectedTimeRange) {
-            TimeRange.DAILY -> DAILY_MAX_DAYS
+            TimeRange.DAILY -> DAILY_MAX_MONTHS
             TimeRange.WEEKLY -> WEEKLY_MAX_MONTHS
             TimeRange.MONTHLY -> MONTHLY_MAX_MONTHS
         }
@@ -299,7 +300,7 @@ class HealthUiStateMapper @Inject constructor(
     private fun getDefaultLocale() = localeProvider.getDefaultLocale()
 
     companion object {
-        private const val DAILY_MAX_DAYS = 30L
+        private const val DAILY_MAX_MONTHS = 1L
         private const val WEEKLY_MAX_MONTHS = 3L
         private const val MONTHLY_MAX_MONTHS = 6L
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapper.kt
@@ -100,9 +100,9 @@ class HealthUiStateMapper @Inject constructor(
 
     private fun mapXValue(selectedTimeRange: TimeRange, zonedDateTime: ZonedDateTime): Float {
         return when (selectedTimeRange) {
-            TimeRange.DAILY -> zonedDateTime.dayOfYear.toFloat()
-            TimeRange.WEEKLY -> (zonedDateTime.dayOfYear / 7).toFloat()
-            TimeRange.MONTHLY -> zonedDateTime.monthValue.toFloat()
+            TimeRange.DAILY -> zonedDateTime.year.toFloat() + (zonedDateTime.dayOfYear - 1) / 365f
+            TimeRange.WEEKLY -> (zonedDateTime.toEpochSecond() / (7 * 24 * 60 * 60)).toFloat()
+            TimeRange.MONTHLY -> zonedDateTime.year.toFloat() + (zonedDateTime.monthValue - 1) / 12f
         }
     }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/HealthChart.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/HealthChart.kt
@@ -160,7 +160,7 @@ private fun rememberValueFormater(
                 ZonedDateTime.of(ZonedDateTime.now().year, 1, 1, 0, 0, 0, 0, ZoneId.systemDefault())
             val date = when (uiState.selectedTimeRange) {
                 TimeRange.DAILY -> beginOfYear.plusDays(value.toLong())
-                TimeRange.WEEKLY -> @Suppress("MagicNumbers") beginOfYear.plusDays(value.toLong() * 7)
+                TimeRange.WEEKLY -> @Suppress("MagicNumber") beginOfYear.plusDays(value.toLong() * 7)
                 TimeRange.MONTHLY -> beginOfYear.plusMonths(value.toLong())
             }
             val pattern = when (uiState.selectedTimeRange) {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -2,7 +2,7 @@
 <resources>
     <string name="app_name">Spezi</string>
     <string name="home">Startseite</string>
-    <string name="heart_health">Herzgesundheit</string>
+    <string name="heart_health">Gesundheit</string>
     <string name="medication">Medikation</string>
     <string name="education">Bildung</string>
     <string name="new_measurement">Neue Messung</string>
@@ -18,4 +18,18 @@
     <string name="info_icon_content_description">Info Icon</string>
     <string name="blood_pressure_icon_content_description">Blutdruck Icon</string>
     <string name="new_measurement_text">Bitte nehmen Sie eine neue Messung vor.</string>
+    <string name="time_range_daily">Täglich</string>
+    <string name="time_range_weekly">Wöchentlich</string>
+    <string name="time_range_monthly">Monatlich</string>
+    <string name="health_history">Historie</string>
+    <string name="symptom_type_overall">Allgemein</string>
+    <string name="symptom_type_physical">Physisch</string>
+    <string name="symptom_type_social">Sozial</string>
+    <string name="symptom_type_quality">Qualität</string>
+    <string name="symptom_type_specific">Spezifisch</string>
+    <string name="symptom_type_dizziness">Schwindel</string>
+    <string name="health_tab_title_symptoms">Symptome</string>
+    <string name="health_tab_title_weight">Gewicht</string>
+    <string name="health_tab_title_blood_pressure">BD</string>
+    <string name="health_tab_title_heart_rate">Herzfrequenz</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <resources>
     <string name="app_name">Spezi</string>
     <string name="home">Home</string>
-    <string name="heart_health">Heart Health</string>
+    <string name="heart_health">Health</string>
     <string name="medication">Medication</string>
     <string name="education">Education</string>
     <string name="new_measurement">New Measurement</string>
@@ -27,4 +27,8 @@
     <string name="symptom_type_quality">Quality</string>
     <string name="symptom_type_specific">Specific</string>
     <string name="symptom_type_dizziness">Dizziness</string>
+    <string name="health_tab_title_symptoms">Symptoms</string>
+    <string name="health_tab_title_weight">Weight</string>
+    <string name="health_tab_title_blood_pressure">BP</string>
+    <string name="health_tab_title_heart_rate">Heart Rate</string>
 </resources>


### PR DESCRIPTION
# *Tab titles display*

## :recycle: Current situation & Problem
In smaller devices the tab titles are displayed in two rows which causes the tab row to increase its height

## :gear: Release Notes 
Shorter titles were used and missing translations were added

![image](https://github.com/user-attachments/assets/3730d18b-5b5e-4cba-a3dc-9c98ea7222de)

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
