### PR TITLE
Task 39: Loading states

### DIFF
--- a/.github/workflows/build-test-analyze.yml
+++ b/.github/workflows/build-test-analyze.yml
@@ -115,7 +115,7 @@ jobs:
           profile: ${{ matrix.profile }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -wipe-data -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: |
             sdkmanager --list
@@ -128,7 +128,7 @@ jobs:
           profile: ${{ matrix.profile }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -wipe-data -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
           script: bundle exec fastlane connectedCheck
       - name: Upload JaCoCo report to Codecov

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/AppNavigationTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/AppNavigationTest.kt
@@ -21,10 +21,12 @@ class AppNavigationTest {
     @get:Rule(order = 2)
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @get:Rule
+    @get:Rule(order = 3)
     val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
         Manifest.permission.BLUETOOTH_CONNECT,
         Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
     )
 
     @Inject

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreenTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreenTest.kt
@@ -1,6 +1,8 @@
 package edu.stanford.bdh.engagehf.bluetooth.screen
 
+import android.Manifest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import edu.stanford.bdh.engagehf.R
@@ -19,6 +21,14 @@ class BluetoothScreenTest {
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComposeContentActivity>()
+
+    @get:Rule
+    val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    )
 
     @Before
     fun init() {

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
@@ -24,7 +24,6 @@ class MedicationScreenTest {
         setUiState(MedicationUiState.Loading)
         medicationScreen {
             assertLoadingIsDisplayed()
-            assertCenteredContent()
         }
     }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModel.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModel.kt
@@ -76,9 +76,9 @@ class BluetoothViewModel @Inject internal constructor(
                 logger.i { "Received BLEService event $event" }
                 when (event) {
                     BLEServiceEvent.BluetoothNotEnabled -> _events.emit(Event.EnableBluetooth)
-                    is BLEServiceEvent.MissingPermissions -> _events.emit(
-                        Event.RequestPermissions(event.permissions)
-                    )
+                    is BLEServiceEvent.MissingPermissions -> _uiState.update {
+                        it.copy(missingPermissions = event.permissions)
+                    }
 
                     is BLEServiceEvent.GenericError -> _uiState.update {
                         it.copy(bluetooth = BluetoothUiState.Error("Something went wrong!"))
@@ -202,6 +202,10 @@ class BluetoothViewModel @Inject internal constructor(
             is Action.ToggleExpand -> {
                 handleToggleExpandAction(action)
             }
+
+            is Action.PermissionGranted -> {
+                onPermissionGranted(action = action)
+            }
         }
     }
 
@@ -280,8 +284,13 @@ class BluetoothViewModel @Inject internal constructor(
         }
     }
 
+    private fun onPermissionGranted(action: Action.PermissionGranted) {
+        val missingPermissions = _uiState.value.missingPermissions.filter { it != action.permission }
+        _uiState.update { it.copy(missingPermissions = missingPermissions) }
+        bleService.start()
+    }
+
     interface Event {
         object EnableBluetooth : Event
-        data class RequestPermissions(val permissions: List<String>) : Event
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/VitalDisplay.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/VitalDisplay.kt
@@ -1,12 +1,13 @@
 package edu.stanford.bdh.engagehf.bluetooth.component
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CardDefaults
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,6 +19,8 @@ import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
 import edu.stanford.bdh.engagehf.bluetooth.component.VitalDisplayDataFactory.createVitalDisplayState
 import edu.stanford.bdh.engagehf.bluetooth.data.models.VitalDisplayData
+import edu.stanford.spezi.core.design.component.RectangleShimmerEffect
+import edu.stanford.spezi.core.design.component.height
 import edu.stanford.spezi.core.design.theme.Colors
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
@@ -89,14 +92,23 @@ fun VitalDisplay(
                 }
 
                 OperationStatus.PENDING -> {
-                    Box(
+                    Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(top = Spacings.small)
+                            .padding(vertical = Spacings.medium)
                             .testIdentifier(WeightDisplayTestIdentifier.PENDING),
-                        contentAlignment = Alignment.Center
+                        verticalArrangement = Arrangement.spacedBy(Spacings.medium)
                     ) {
-                        CircularProgressIndicator(color = Colors.primary)
+                        RectangleShimmerEffect(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction = 0.8f)
+                                .height(textStyle = TextStyles.headlineMedium)
+                        )
+                        RectangleShimmerEffect(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction = 0.5f)
+                                .height(textStyle = TextStyles.bodySmall)
+                        )
                     }
                 }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
@@ -160,7 +160,8 @@ class BluetoothUiStateMapper @Inject constructor(
                 status = OperationStatus.FAILURE,
                 date = null,
                 value = null,
-                unit = null
+                unit = null,
+                error = result.exceptionOrNull()?.message
             )
 
             successResult != null -> onSuccess(successResult)

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
@@ -8,4 +8,5 @@ sealed interface Action {
     data object DismissDialog : Action
     data class MessageItemClicked(val message: Message) : Action
     data class ToggleExpand(val message: Message) : Action
+    data class PermissionGranted(val permission: String) : Action
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/UiState.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/UiState.kt
@@ -14,5 +14,6 @@ data class UiState(
     ),
     val messages: List<Message> = emptyList(),
     val bluetooth: BluetoothUiState = BluetoothUiState.Idle,
+    val missingPermissions: List<String> = emptyList(),
     val measurementDialog: MeasurementDialogUiState = MeasurementDialogUiState(),
 )

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreen.kt
@@ -49,8 +49,6 @@ import edu.stanford.spezi.core.utils.extensions.testIdentifier
 import kotlinx.coroutines.flow.Flow
 import java.time.ZonedDateTime
 
-private const val BOX_CONSTRAINT_HEIGHT = 0.35f
-
 @Composable
 fun BluetoothScreen() {
     val viewModel = hiltViewModel<BluetoothViewModel>()
@@ -99,7 +97,7 @@ private fun BluetoothScreen(
                 Text(
                     text = "No messages",
                     style = TextStyles.bodyMedium,
-                    modifier = Modifier.padding(Spacings.small)
+                    modifier = Modifier.padding(vertical = Spacings.small)
                 )
             }
         }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/MeasurementDialog.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/MeasurementDialog.kt
@@ -5,10 +5,8 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -22,8 +20,7 @@ import edu.stanford.bdh.engagehf.R
 import edu.stanford.bdh.engagehf.bluetooth.data.models.Action
 import edu.stanford.bdh.engagehf.bluetooth.data.models.MeasurementDialogUiState
 import edu.stanford.spezi.core.bluetooth.data.model.Measurement
-import edu.stanford.spezi.core.design.component.Button
-import edu.stanford.spezi.core.design.theme.Sizes
+import edu.stanford.spezi.core.design.component.AsyncTextButton
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.TextStyles
 import edu.stanford.spezi.core.utils.extensions.testIdentifier
@@ -78,22 +75,15 @@ fun MeasurementDialog(
                 }
             },
             confirmButton = {
-                Button(
+                AsyncTextButton(
+                    text = stringResource(R.string.confirm_button_text),
+                    isLoading = uiState.isProcessing,
                     onClick = {
                         uiState.measurement?.let {
                             onAction(Action.ConfirmMeasurement(it))
                         }
-                    },
-                    enabled = uiState.isProcessing.not()
-                ) {
-                    if (uiState.isProcessing) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(Sizes.Icon.small)
-                        )
-                    } else {
-                        Text(stringResource(R.string.confirm_button_text))
                     }
-                }
+                )
             },
             dismissButton = {
                 FilledTonalButton(

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
@@ -4,11 +4,13 @@ import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowDropDown
@@ -27,7 +29,10 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import edu.stanford.bdh.engagehf.medication.ui.MedicationCardUiModel
 import edu.stanford.bdh.engagehf.medication.ui.MedicationScreenTestIdentifier
 import edu.stanford.bdh.engagehf.medication.ui.MedicationViewModel
+import edu.stanford.spezi.core.design.component.CircleShimmerEffect
+import edu.stanford.spezi.core.design.component.RectangleShimmerEffect
 import edu.stanford.spezi.core.design.component.VerticalSpacer
+import edu.stanford.spezi.core.design.component.height
 import edu.stanford.spezi.core.design.theme.Colors
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
@@ -43,23 +48,16 @@ fun MedicationCard(
     model: MedicationCardUiModel,
     onAction: (MedicationViewModel.Action) -> Unit,
 ) {
-    ElevatedCard(
-        elevation = CardDefaults.elevatedCardElevation(
-            defaultElevation = Sizes.Elevation.medium,
-        ),
-        colors = CardDefaults.cardColors(
-            containerColor = Colors.surface.lighten(),
-        ),
+    MedicationElevatedCard(
         modifier = modifier
+            .padding(bottom = Spacings.medium)
             .testIdentifier(
                 identifier = MedicationScreenTestIdentifier.SUCCESS_MEDICATION_CARD_ROOT,
                 suffix = model.id
             )
             .clickable {
                 onAction(
-                    MedicationViewModel.Action.ToggleExpand(
-                        medicationId = model.id
-                    )
+                    MedicationViewModel.Action.ToggleExpand(medicationId = model.id)
                 )
             },
     ) {
@@ -147,6 +145,51 @@ fun MedicationCard(
             }
         }
     }
+}
+
+@Composable
+fun LoadingMedicationCard() {
+    MedicationElevatedCard(modifier = Modifier.padding(bottom = Spacings.medium)) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacings.medium),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            CircleShimmerEffect(modifier = Modifier.size(Sizes.Icon.medium))
+
+            Column(modifier = Modifier.padding(Spacings.small)) {
+                RectangleShimmerEffect(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.8f)
+                        .height(textStyle = TextStyles.titleLarge)
+                )
+                VerticalSpacer()
+                RectangleShimmerEffect(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.5f)
+                        .height(textStyle = TextStyles.titleSmall)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun MedicationElevatedCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ElevatedCard(
+        elevation = CardDefaults.elevatedCardElevation(
+            defaultElevation = Sizes.Elevation.medium,
+        ),
+        colors = CardDefaults.cardColors(
+            containerColor = Colors.surface.lighten(),
+        ),
+        modifier = modifier,
+        content = content,
+    )
 }
 
 @ThemePreviews

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
@@ -1,7 +1,5 @@
 package edu.stanford.bdh.engagehf.medication.components
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
@@ -10,8 +8,6 @@ import androidx.compose.ui.tooling.preview.PreviewParameter
 import edu.stanford.bdh.engagehf.medication.ui.MedicationCardUiModel
 import edu.stanford.bdh.engagehf.medication.ui.MedicationUiState
 import edu.stanford.bdh.engagehf.medication.ui.MedicationViewModel
-import edu.stanford.spezi.core.design.component.VerticalSpacer
-import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 
@@ -21,14 +17,9 @@ fun MedicationList(
     uiState: MedicationUiState.Success,
     onAction: (MedicationViewModel.Action) -> Unit,
 ) {
-    LazyColumn(
-        modifier = modifier
-            .fillMaxSize()
-            .padding(Spacings.medium)
-    ) {
+    LazyColumn(modifier = modifier) {
         items(uiState.uiModels) {
             MedicationCard(model = it, onAction = onAction)
-            VerticalSpacer()
         }
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
@@ -1,13 +1,7 @@
 package edu.stanford.bdh.engagehf.medication.ui
 
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -16,21 +10,17 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
+import edu.stanford.bdh.engagehf.medication.components.LoadingMedicationCard
 import edu.stanford.bdh.engagehf.medication.components.MedicationList
 import edu.stanford.bdh.engagehf.medication.components.getMedicationCardUiModel
 import edu.stanford.spezi.core.design.component.CenteredBoxContent
-import edu.stanford.spezi.core.design.component.CircularShimmerEffect
-import edu.stanford.spezi.core.design.component.RectangleShimmerEffect
-import edu.stanford.spezi.core.design.component.VerticalSpacer
+import edu.stanford.spezi.core.design.component.RepeatingLazyColumn
 import edu.stanford.spezi.core.design.theme.Colors
-import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.TextStyles
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 import edu.stanford.spezi.core.utils.extensions.testIdentifier
-
-private const val LOADING_CARDS = 6
 
 @Composable
 fun MedicationScreen() {
@@ -70,45 +60,23 @@ fun MedicationScreen(
         }
 
         MedicationUiState.Loading -> {
-            LazyColumn(
+            RepeatingLazyColumn(
                 modifier = Modifier
-                    .testIdentifier(MedicationScreenTestIdentifier.LOADING)
                     .fillMaxSize()
-            ) {
-                items(LOADING_CARDS) { LoadingMedicationCard() }
-            }
+                    .padding(Spacings.medium)
+                    .testIdentifier(MedicationScreenTestIdentifier.LOADING),
+                content = { LoadingMedicationCard() }
+            )
         }
 
         is MedicationUiState.Success -> {
             MedicationList(
                 uiState = uiState,
                 onAction = onAction,
-                modifier = Modifier.testIdentifier(MedicationScreenTestIdentifier.SUCCESS)
-            )
-        }
-    }
-}
-
-@Composable
-private fun LoadingMedicationCard() {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(Spacings.medium)
-    ) {
-        CircularShimmerEffect(modifier = Modifier.size(Sizes.Content.large))
-
-        Column(modifier = Modifier.padding(Spacings.small)) {
-            RectangleShimmerEffect(
                 modifier = Modifier
-                    .fillMaxWidth()
-                    .height(Sizes.Content.small)
-            )
-            VerticalSpacer()
-            RectangleShimmerEffect(
-                modifier = Modifier
-                    .fillMaxWidth(fraction = 0.5f)
-                    .height(Sizes.Content.small)
+                    .fillMaxSize()
+                    .padding(Spacings.medium)
+                    .testIdentifier(MedicationScreenTestIdentifier.SUCCESS)
             )
         }
     }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
@@ -1,6 +1,13 @@
 package edu.stanford.bdh.engagehf.medication.ui
 
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -12,12 +19,18 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import edu.stanford.bdh.engagehf.medication.components.MedicationList
 import edu.stanford.bdh.engagehf.medication.components.getMedicationCardUiModel
 import edu.stanford.spezi.core.design.component.CenteredBoxContent
+import edu.stanford.spezi.core.design.component.CircularShimmerEffect
+import edu.stanford.spezi.core.design.component.RectangleShimmerEffect
+import edu.stanford.spezi.core.design.component.VerticalSpacer
 import edu.stanford.spezi.core.design.theme.Colors
-import edu.stanford.spezi.core.design.theme.Colors.primary
+import edu.stanford.spezi.core.design.theme.Sizes
+import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.TextStyles
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 import edu.stanford.spezi.core.utils.extensions.testIdentifier
+
+private const val LOADING_CARDS = 6
 
 @Composable
 fun MedicationScreen() {
@@ -57,12 +70,12 @@ fun MedicationScreen(
         }
 
         MedicationUiState.Loading -> {
-            CenteredBoxContent {
-                CircularProgressIndicator(
-                    modifier = Modifier
-                        .testIdentifier(MedicationScreenTestIdentifier.LOADING),
-                    color = primary
-                )
+            LazyColumn(
+                modifier = Modifier
+                    .testIdentifier(MedicationScreenTestIdentifier.LOADING)
+                    .fillMaxSize()
+            ) {
+                items(LOADING_CARDS) { LoadingMedicationCard() }
             }
         }
 
@@ -71,6 +84,31 @@ fun MedicationScreen(
                 uiState = uiState,
                 onAction = onAction,
                 modifier = Modifier.testIdentifier(MedicationScreenTestIdentifier.SUCCESS)
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingMedicationCard() {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(Spacings.medium)
+    ) {
+        CircularShimmerEffect(modifier = Modifier.size(Sizes.Content.large))
+
+        Column(modifier = Modifier.padding(Spacings.small)) {
+            RectangleShimmerEffect(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(Sizes.Content.small)
+            )
+            VerticalSpacer()
+            RectangleShimmerEffect(
+                modifier = Modifier
+                    .fillMaxWidth(fraction = 0.5f)
+                    .height(Sizes.Content.small)
             )
         }
     }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageItem.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageItem.kt
@@ -58,10 +58,7 @@ fun MessageItem(
             containerColor = Colors.surface.lighten(),
         ),
         modifier = modifier
-            .padding(
-                top = Spacings.small,
-                bottom = Spacings.small,
-            )
+            .padding(vertical = Spacings.small)
             .fillMaxWidth()
     ) {
         Column(

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModelTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModelTest.kt
@@ -169,7 +169,7 @@ class BluetoothViewModelTest {
         bleServiceEvents.emit(event)
 
         // then
-        assertEvent(event = BluetoothViewModel.Event.RequestPermissions(permissions))
+        assertThat(bluetoothViewModel.uiState.value.missingPermissions).isEqualTo(permissions)
     }
 
     @Test
@@ -511,6 +511,22 @@ class BluetoothViewModelTest {
         assertThat(
             bluetoothViewModel.uiState.value.messages.first().isExpanded
         ).isEqualTo(isExpanded.not())
+    }
+
+    @Test
+    fun `it should handle permission granted action correctly`() = runTestUnconfined {
+        // given
+        val permissions = listOf("permission1")
+        val event = BLEServiceEvent.MissingPermissions(permissions)
+        createViewModel()
+        bleServiceEvents.emit(event)
+
+        // when
+        bluetoothViewModel.onAction(Action.PermissionGranted(permission = permissions.first()))
+
+        // then
+        assertThat(bluetoothViewModel.uiState.value.missingPermissions).isEmpty()
+        verify(exactly = 2) { bleService.start() }
     }
 
     private fun assertBluetothUiState(state: BluetoothUiState) {

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/health/HealthUiStateMapperTest.kt
@@ -17,6 +17,7 @@ class HealthUiStateMapperTest {
 
     private val localeProvider: LocaleProvider = mockk()
     private val healthUiStateMapper = HealthUiStateMapper(localeProvider = localeProvider)
+    private val zonedDateTime = ZonedDateTime.now()
 
     @Before
     fun setup() {
@@ -99,7 +100,6 @@ class HealthUiStateMapperTest {
                 day = 4,
             ),
             createWeightRecord(
-                month = 9,
                 day = 5,
             ),
         )
@@ -113,18 +113,18 @@ class HealthUiStateMapperTest {
         assertThat(result.tableData).isNotEmpty()
         assertThat(result.tableData.size).isEqualTo(3)
         assertThat(result.chartData.size).isEqualTo(1)
-        assertThat(result.chartData[0].xValues.size).isEqualTo(2)
-        assertThat(result.chartData[0].yValues.size).isEqualTo(2)
+        assertThat(result.chartData[0].xValues.size).isEqualTo(1)
+        assertThat(result.chartData[0].yValues.size).isEqualTo(1)
         assertThat(result.newestData).isNotNull()
         assertThat(result.infoRowData.formattedValue).isNotEmpty()
         assertThat(result.infoRowData.formattedDate).isNotEmpty()
     }
 
     private fun createWeightRecord(
-        year: Int = 2024,
-        month: Int = 8,
-        day: Int = 1,
-        hour: Int = 5,
+        year: Int = zonedDateTime.year,
+        month: Int = zonedDateTime.monthValue,
+        day: Int = zonedDateTime.dayOfMonth,
+        hour: Int = zonedDateTime.hour,
         minute: Int = 4,
         second: Int = 0,
         nanoOfSecond: Int = 0,
@@ -146,6 +146,6 @@ class HealthUiStateMapperTest {
         )
     }
 
-    private fun HealthUiStateMapper.map(records: List<Record>, timeRange: TimeRange = TimeRange.DAILY) =
+    private fun HealthUiStateMapper.map(records: List<Record>, timeRange: TimeRange = TimeRange.MONTHLY) =
         (mapToHealthData(records, timeRange) as HealthUiState.Success).data
 }

--- a/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
+++ b/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
@@ -182,6 +182,8 @@ internal class BLEServiceImpl @Inject constructor(
         val REQUIRED_PERMISSIONS = listOf(
             Manifest.permission.BLUETOOTH_CONNECT,
             Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
         )
     }
 }

--- a/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
+++ b/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
@@ -107,6 +107,8 @@ class BLEServiceTest {
         val expectedPermissions = listOf(
             Manifest.permission.BLUETOOTH_CONNECT,
             Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
         )
 
         // when

--- a/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/AsyncButtonTest.kt
+++ b/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/AsyncButtonTest.kt
@@ -1,0 +1,78 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.test.assert
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.isEnabled
+import androidx.compose.ui.test.isNotEnabled
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import edu.stanford.spezi.core.design.action.PendingActions
+import edu.stanford.spezi.core.testing.onNodeWithIdentifier
+import org.junit.Rule
+import org.junit.Test
+
+class AsyncButtonTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val root = AsyncButtonTestIdentifier.ROOT
+    private val pendingActions = PendingActions<Action>()
+
+    @Test
+    fun testButtonIsDisplayed() {
+        val title = "AsyncButton"
+        composeTestRule.setContent {
+            AsyncButton {
+                Text(text = title)
+            }
+        }
+
+        composeTestRule.onNodeWithIdentifier(root).assertIsDisplayed()
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    @Test
+    fun testButtonIsEnabled() {
+        val title = "AsyncButton"
+        composeTestRule.setContent {
+            AsyncButton(enabled = true, isLoading = pendingActions.contains(action = Action)) {
+                Text(text = title)
+            }
+        }
+
+        composeTestRule.onNodeWithIdentifier(root).assert(isEnabled())
+    }
+
+    @Test
+    fun testLoadingState() {
+        val title = "AsyncButton"
+        val pendingActions = pendingActions.plus(Action)
+        composeTestRule.setContent {
+            AsyncButton(enabled = true, isLoading = pendingActions.contains(action = Action)) {
+                Text(text = title)
+            }
+        }
+
+        composeTestRule.onNodeWithIdentifier(root).assert(isNotEnabled())
+        composeTestRule.onNodeWithIdentifier(AsyncButtonTestIdentifier.LOADING).assertIsDisplayed()
+        composeTestRule.onNodeWithText(title).assertIsNotDisplayed()
+    }
+
+    @Test
+    fun testAsyncTestButton() {
+        val title = "AsyncButton"
+        composeTestRule.setContent {
+            AsyncTextButton(text = title)
+        }
+
+        composeTestRule.onNodeWithIdentifier(root).assert(isEnabled())
+        composeTestRule.onNodeWithIdentifier(AsyncButtonTestIdentifier.LOADING)
+            .assertIsNotDisplayed()
+        composeTestRule.onNodeWithText(title).assertIsDisplayed()
+    }
+
+    private object Action
+}

--- a/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumnTest.kt
+++ b/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumnTest.kt
@@ -1,0 +1,44 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.material3.Text
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import edu.stanford.spezi.core.testing.onAllNodes
+import edu.stanford.spezi.core.testing.onNodeWithIdentifier
+import edu.stanford.spezi.core.utils.extensions.testIdentifier
+import org.junit.Rule
+import org.junit.Test
+
+class RepeatingLazyColumnTest {
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    @Test
+    fun testRepeatingLazyColumn() {
+        val title = "#same"
+        val count = 3
+        val root = Identifier.ROOT
+        composeTestRule.setContent {
+            RepeatingLazyColumn(
+                modifier = Modifier.testIdentifier(root),
+                itemCount = count,
+                content = {
+                    Text(
+                        modifier = Modifier
+                            .testIdentifier(Identifier.CONTENT),
+                        text = title
+                    )
+                }
+            )
+        }
+
+        composeTestRule.onNodeWithIdentifier(root).assertIsDisplayed()
+        composeTestRule.onAllNodes(Identifier.CONTENT).assertCountEquals(count)
+    }
+
+    private enum class Identifier {
+        ROOT, CONTENT
+    }
+}

--- a/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffectTest.kt
+++ b/core/design/src/androidTest/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffectTest.kt
@@ -1,0 +1,55 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.junit4.createComposeRule
+import edu.stanford.spezi.core.testing.onNodeWithIdentifier
+import edu.stanford.spezi.core.utils.extensions.testIdentifier
+import org.junit.Rule
+import org.junit.Test
+
+class ShimmerEffectTest {
+
+    @get:Rule
+    val composeTestRule = createComposeRule()
+
+    private val identifier = Identifier.ROOT
+
+    @Test
+    fun testShimmerBox() {
+        composeTestRule.setContent {
+            ShimmerEffectBox(
+                modifier = Modifier.fillMaxSize().testIdentifier(identifier)
+            )
+        }
+
+        composeTestRule.onNodeWithIdentifier(identifier).assertIsDisplayed()
+    }
+
+    @Test
+    fun testCircleShimmerBox() {
+        composeTestRule.setContent {
+            CircleShimmerEffect(
+                modifier = Modifier.fillMaxSize().testIdentifier(identifier)
+            )
+        }
+
+        composeTestRule.onNodeWithIdentifier(identifier).assertIsDisplayed()
+    }
+
+    @Test
+    fun testRectangleShimmerBox() {
+        composeTestRule.setContent {
+            RectangleShimmerEffect(
+                modifier = Modifier.fillMaxSize().testIdentifier(identifier)
+            )
+        }
+
+        composeTestRule.onNodeWithIdentifier(identifier).assertIsDisplayed()
+    }
+
+    private enum class Identifier {
+        ROOT,
+    }
+}

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/action/PendingActions.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/action/PendingActions.kt
@@ -1,0 +1,78 @@
+package edu.stanford.spezi.core.design.action
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
+import androidx.compose.runtime.remember
+
+/**
+ * An immutable action holder data class to be used in UiStates and to be consumed in Compose
+ * to indicate pending loading async states.
+ *
+ * Example usage:
+ *
+ * ```kotlin
+ * // Screen actions
+ * interface Action {
+ *     data object LongOperation : Action
+ * }
+ *
+ * // Screen ui state
+ * data class UiState(
+ *     val title: String,
+ *     val pendingActions: PendingActions<Action> = PendingActions()
+ * )
+ *
+ * val uiState = MutableStateFlow(UiState(title = "PendingActions"))
+ *
+ * // Adding pending action before executing a blocking operation and removing afterwards
+ * fun onAction(action: Action) {
+ *     when (action) {
+ *         is Action.LongOperation -> {
+ *             uiState.update { it.copy(pendingActions = it.pendingActions + action) }
+ *             // perform blocking operation
+ *             uiState.update { it.copy(pendingActions = it.pendingActions - action) }
+ *         }
+ *     }
+ * }
+ *
+ * // Using isLoading inside compose
+ * @Composable
+ * fun PendingActions(uiState: UiState) {
+ *     val isLoading = uiState.pendingActions.isLoading(action = Action.LongOperation)
+ *     // rest of the screen
+ * }
+ *
+ * ```
+ */
+@Immutable
+data class PendingActions<T : Any>(
+    private val actions: List<T> = emptyList(),
+) {
+
+    /**
+     * Returns a new PendingActions instance by appending `action`
+     * @param action action to be appended
+     * @return A new PendingActions instance that contains existing actions plus `action`
+     */
+    operator fun plus(action: T) = PendingActions(actions + action)
+
+    /**
+     * Returns a new PendingActions instance by removing all actions of the same type as `action`
+     * @param action action type to be removed
+     * @return A new PendingActions instance that contains existing actions without `action`
+     */
+    operator fun minus(action: T) = PendingActions(
+        actions = actions.filter { it.javaClass != action.javaClass }
+    )
+
+    /**
+     * @param action action to be checked whether an action of the same type is contained
+     * @return true if any other action of the same type is contained, false otherwise
+     */
+    @Composable
+    fun contains(action: T): Boolean {
+        return remember(this, action) {
+            actions.any { it.javaClass == action.javaClass }
+        }
+    }
+}

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/AsyncButton.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/AsyncButton.kt
@@ -16,6 +16,7 @@ import edu.stanford.spezi.core.design.theme.Colors
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.ThemePreviews
+import edu.stanford.spezi.core.utils.extensions.testIdentifier
 
 /**
  * A button that renders a circular progress CircularProgressIndicator in case of loading or
@@ -46,7 +47,7 @@ fun AsyncButton(
 ) {
     Button(
         onClick = onClick,
-        modifier = modifier,
+        modifier = modifier.testIdentifier(AsyncButtonTestIdentifier.ROOT),
         enabled = enabled && isLoading.not(),
         shape = shape,
         colors = ButtonDefaults.buttonColors(
@@ -63,7 +64,9 @@ fun AsyncButton(
             if (isLoading) {
                 CircularProgressIndicator(
                     color = contentColor,
-                    modifier = Modifier.size(Sizes.Icon.small)
+                    modifier = Modifier
+                        .testIdentifier(AsyncButtonTestIdentifier.LOADING)
+                        .size(Sizes.Icon.small)
                 )
             } else {
                 content()
@@ -110,6 +113,10 @@ fun AsyncTextButton(
         onClick = onClick,
         content = { Text(text = text, color = textColor) }
     )
+}
+
+enum class AsyncButtonTestIdentifier {
+    ROOT, LOADING
 }
 
 @ThemePreviews

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/AsyncButton.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/AsyncButton.kt
@@ -1,0 +1,124 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import edu.stanford.spezi.core.design.theme.Colors
+import edu.stanford.spezi.core.design.theme.Sizes
+import edu.stanford.spezi.core.design.theme.SpeziTheme
+import edu.stanford.spezi.core.design.theme.ThemePreviews
+
+/**
+ * A button that renders a circular progress CircularProgressIndicator in case of loading or
+ * [content] otherwise
+ *
+ * @param modifier Modifier to be applied to the button
+ * @param isLoading whether the button should render the content or it's loading indicator
+ * @param enabled whether the button is enabled. Note that the button will only be enabled if
+ * [enabled] is true and [isLoading] is false.
+ * @param shape shape to be applied to the button container
+ * @param containerColor color of button container
+ * @param contentColor color of content
+ * @param contentPadding padding to be applied on the content
+ * @param onClick click action
+ * @param content content of the button
+ */
+@Composable
+fun AsyncButton(
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = isLoading.not(),
+    shape: Shape = ButtonDefaults.shape,
+    containerColor: Color = ButtonDefaults.buttonColors().containerColor,
+    contentColor: Color = ButtonDefaults.buttonColors().contentColor,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    onClick: () -> Unit = {},
+    content: @Composable RowScope.() -> Unit,
+) {
+    Button(
+        onClick = onClick,
+        modifier = modifier,
+        enabled = enabled && isLoading.not(),
+        shape = shape,
+        colors = ButtonDefaults.buttonColors(
+            containerColor = containerColor,
+            contentColor = contentColor,
+            disabledContainerColor = if (containerColor == Colors.transparent) {
+                Colors.transparent
+            } else {
+                Color.Unspecified
+            }
+        ),
+        contentPadding = contentPadding,
+        content = {
+            if (isLoading) {
+                CircularProgressIndicator(
+                    color = contentColor,
+                    modifier = Modifier.size(Sizes.Icon.small)
+                )
+            } else {
+                content()
+            }
+        },
+    )
+}
+
+/**
+ * A button that renders a circular progress CircularProgressIndicator in case of loading or
+ * [text] otherwise
+ *
+ * @param text String text of the button
+ * @param modifier Modifier to be applied to the button
+ * @param isLoading whether the button should render the content or it's loading indicator
+ * @param enabled whether the button is enabled. Note that the button will only be enabled if
+ * [enabled] is true and [isLoading] is false.
+ * @param shape shape to be applied to the button container
+ * @param containerColor color of button container
+ * @param textColor color of text
+ * @param contentPadding padding to be applied on the content
+ * @param onClick click action
+ */
+@Composable
+fun AsyncTextButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    isLoading: Boolean = false,
+    enabled: Boolean = isLoading.not(),
+    shape: Shape = ButtonDefaults.shape,
+    containerColor: Color = ButtonDefaults.buttonColors().containerColor,
+    textColor: Color = ButtonDefaults.buttonColors().contentColor,
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
+    onClick: () -> Unit = {},
+) {
+    AsyncButton(
+        modifier = modifier,
+        isLoading = isLoading,
+        enabled = enabled,
+        shape = shape,
+        containerColor = containerColor,
+        contentColor = textColor,
+        contentPadding = contentPadding,
+        onClick = onClick,
+        content = { Text(text = text, color = textColor) }
+    )
+}
+
+@ThemePreviews
+@Composable
+fun AsyncButtonPreviews() {
+    SpeziTheme {
+        Column {
+            AsyncTextButton(text = "AsyncTextButton", isLoading = true)
+            AsyncTextButton(text = "AsyncTextButton")
+        }
+    }
+}

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumn.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumn.kt
@@ -49,4 +49,3 @@ fun RepeatingLazyColumnPreview() {
         )
     }
 }
-

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumn.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/RepeatingLazyColumn.kt
@@ -1,0 +1,52 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import edu.stanford.spezi.core.design.theme.Spacings
+import edu.stanford.spezi.core.design.theme.SpeziTheme
+import edu.stanford.spezi.core.design.theme.ThemePreviews
+
+private const val DEFAULT_REPEATING_ITEMS_COUNT = 7
+
+/**
+ * Renders a lazy column with [itemCount] same [content]s. Helpful when rendering loading list items
+ *
+ * @param modifier Modifier to be applied
+ * @param itemCount count of items to be rendered, defaults to 7
+ * @param content content of the item
+ */
+@Composable
+fun RepeatingLazyColumn(
+    modifier: Modifier = Modifier,
+    itemCount: Int = DEFAULT_REPEATING_ITEMS_COUNT,
+    content: @Composable LazyItemScope.() -> Unit,
+) {
+    LazyColumn(modifier = modifier) {
+        items(itemCount) { content() }
+    }
+}
+
+@ThemePreviews
+@Composable
+fun RepeatingLazyColumnPreview() {
+    SpeziTheme {
+        RepeatingLazyColumn(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacings.medium),
+            itemCount = 100,
+            content = {
+                Text(
+                    text = "#same",
+                    modifier = Modifier.padding(Spacings.medium)
+                )
+            }
+        )
+    }
+}
+

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffect.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffect.kt
@@ -1,0 +1,134 @@
+package edu.stanford.spezi.core.design.component
+
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.tooling.preview.Preview
+import edu.stanford.spezi.core.design.theme.Sizes
+import edu.stanford.spezi.core.design.theme.Spacings
+import edu.stanford.spezi.core.design.theme.SpeziTheme
+import java.util.concurrent.TimeUnit
+
+data object ShimmerEffectDefaults {
+    val color = Color.LightGray
+    val shape = RectangleShape
+    val durationMillis: Int = TimeUnit.SECONDS.toMillis(1).toInt()
+    internal const val LABEL = "ShimmerEffect"
+}
+
+/**
+ * Renders a Compose Box with a shimmer loading effect
+ * @param modifier Modifier to be applied, to be used for sizing
+ * @param shape Shape to be applied to the shimmer effect
+ * @param duration duration one shimmer iteration
+ * @param color color of the shimmer
+ */
+@Composable
+fun ShimmerEffectBox(
+    modifier: Modifier = Modifier,
+    shape: Shape = ShimmerEffectDefaults.shape,
+    duration: Int = ShimmerEffectDefaults.durationMillis,
+    color: Color = ShimmerEffectDefaults.color,
+) {
+    val shimmerColors = listOf(
+        color.copy(alpha = 0.6f),
+        color.copy(alpha = 0.2f),
+        color.copy(alpha = 0.6f),
+    )
+
+    val transition = rememberInfiniteTransition(label = ShimmerEffectDefaults.LABEL)
+    val translateAnimation = transition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1000f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(duration),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = ShimmerEffectDefaults.LABEL,
+    )
+    val brush = Brush.linearGradient(
+        colors = shimmerColors,
+        start = Offset.Zero,
+        end = Offset(x = translateAnimation.value, y = translateAnimation.value)
+    )
+    Box(modifier = modifier.background(brush, shape))
+}
+
+/**
+ * Renders a rectangle Compose Box with a shimmer loading effect
+ * @param modifier Modifier to be applied, to be used for sizing
+ * @param duration duration one shimmer iteration
+ * @param color color of the shimmer
+ */
+@Composable
+fun RectangleShimmerEffect(
+    modifier: Modifier,
+    duration: Int = ShimmerEffectDefaults.durationMillis,
+    color: Color = ShimmerEffectDefaults.color,
+) {
+    ShimmerEffectBox(
+        modifier = modifier,
+        shape = ShimmerEffectDefaults.shape,
+        duration = duration,
+        color = color,
+    )
+}
+
+/**
+ * Renders a circle Compose Box with a shimmer loading effect
+ * @param modifier Modifier to be applied, to be used for sizing
+ * @param duration duration one shimmer iteration
+ * @param color color of the shimmer
+ */
+@Composable
+fun CircularShimmerEffect(
+    modifier: Modifier,
+    duration: Int = ShimmerEffectDefaults.durationMillis,
+    color: Color = ShimmerEffectDefaults.color,
+) {
+    ShimmerEffectBox(
+        modifier = modifier,
+        shape = CircleShape,
+        duration = duration,
+        color = color,
+    )
+}
+
+@Preview
+@Composable
+fun ShimmerEffectPreview() {
+    SpeziTheme {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacings.medium)
+        ) {
+            CircularShimmerEffect(modifier = Modifier.size(Sizes.Content.large))
+            Column(modifier = Modifier.padding(Spacings.medium)) {
+                RectangleShimmerEffect(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(Sizes.Content.small)
+                )
+            }
+        }
+    }
+}

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffect.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/component/ShimmerEffect.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -14,22 +15,27 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.CornerSize
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
+import edu.stanford.spezi.core.design.theme.TextStyles
+import edu.stanford.spezi.core.design.theme.ThemePreviews
 import java.util.concurrent.TimeUnit
 
 data object ShimmerEffectDefaults {
     val color = Color.LightGray
-    val shape = RectangleShape
+    val shape = RoundedCornerShape(corner = CornerSize(2.dp))
     val durationMillis: Int = TimeUnit.SECONDS.toMillis(1).toInt()
     internal const val LABEL = "ShimmerEffect"
 }
@@ -99,7 +105,7 @@ fun RectangleShimmerEffect(
  * @param color color of the shimmer
  */
 @Composable
-fun CircularShimmerEffect(
+fun CircleShimmerEffect(
     modifier: Modifier,
     duration: Int = ShimmerEffectDefaults.durationMillis,
     color: Color = ShimmerEffectDefaults.color,
@@ -112,21 +118,37 @@ fun CircularShimmerEffect(
     )
 }
 
-@Preview
+/**
+ * Applies the height of the font size, useful when declaring shimmer effects to replicate
+ * a loading text
+ */
+fun Modifier.height(textStyle: TextStyle) = then(Modifier.height(textStyle.fontSize.value.dp))
+
+@ThemePreviews
 @Composable
 fun ShimmerEffectPreview() {
-    SpeziTheme {
+    SpeziTheme(isPreview = true) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(Spacings.medium)
+                .padding(Spacings.medium),
+            verticalAlignment = Alignment.CenterVertically
         ) {
-            CircularShimmerEffect(modifier = Modifier.size(Sizes.Content.large))
-            Column(modifier = Modifier.padding(Spacings.medium)) {
+            CircleShimmerEffect(modifier = Modifier.size(Sizes.Content.large))
+            Column(
+                modifier = Modifier
+                    .padding(Spacings.small),
+                verticalArrangement = Arrangement.spacedBy(Spacings.medium)
+            ) {
                 RectangleShimmerEffect(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(Sizes.Content.small)
+                        .height(textStyle = TextStyles.titleLarge)
+                )
+                RectangleShimmerEffect(
+                    modifier = Modifier
+                        .fillMaxWidth(fraction = 0.4f)
+                        .height(textStyle = TextStyles.bodySmall)
                 )
             }
         }

--- a/core/design/src/main/kotlin/edu/stanford/spezi/core/design/theme/Colors.kt
+++ b/core/design/src/main/kotlin/edu/stanford/spezi/core/design/theme/Colors.kt
@@ -66,6 +66,11 @@ object Colors {
         @Composable
         @ReadOnlyComposable
         get() = scheme.error
+
+    val transparent
+        @Composable
+        @ReadOnlyComposable
+        get() = Color.Transparent
 }
 
 @Suppress("unused")

--- a/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/LoginScreen.kt
+++ b/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/LoginScreen.kt
@@ -5,6 +5,7 @@ package edu.stanford.spezi.module.account.login
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -19,7 +20,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Lock
-import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -38,8 +39,11 @@ import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import edu.stanford.spezi.core.design.component.AsyncTextButton
 import edu.stanford.spezi.core.design.component.validated.outlinedtextfield.ValidatedOutlinedTextField
+import edu.stanford.spezi.core.design.theme.Colors
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.TextStyles.bodyLarge
@@ -135,7 +139,7 @@ You may login to your existing account or create a new one if you don't have one
                     },
                     keyboardOptions = KeyboardOptions.Default.copy(imeAction = ImeAction.Done),
                     keyboardActions = KeyboardActions(onDone = {
-                        onAction(Action.PasswordSignInOrSignUp)
+                        onAction(Action.Async.PasswordSignInOrSignUp)
                     }),
                     trailingIcon = {
                         IconButton(onClick = { onAction(Action.TogglePasswordVisibility) }) {
@@ -152,25 +156,27 @@ You may login to your existing account or create a new one if you don't have one
                     }
                 )
             })
-        TextButton(
+        val forgotPasswordAction = Action.Async.ForgotPassword
+        AsyncTextButton(
+            text = "Forgot Password?",
+            isLoading = uiState.pendingActions.contains(forgotPasswordAction),
+            containerColor = Colors.transparent,
+            contentPadding = PaddingValues(0.dp),
+            textColor = ButtonDefaults.buttonColors().containerColor,
             onClick = {
-                onAction(Action.ForgotPassword)
-            }, modifier = Modifier.align(Alignment.End)
-        ) {
-            Text("Forgot Password?")
-        }
-        Spacer(modifier = Modifier.height(Spacings.medium))
-        Button(
-            onClick = {
-                onAction(Action.PasswordSignInOrSignUp)
+                onAction(forgotPasswordAction)
             },
+            modifier = Modifier.align(Alignment.End)
+        )
+        Spacer(modifier = Modifier.height(Spacings.medium))
+        val passwordSignInOrSignUp = Action.Async.PasswordSignInOrSignUp
+        AsyncTextButton(
+            isLoading = uiState.pendingActions.contains(passwordSignInOrSignUp),
+            text = if (uiState.isAlreadyRegistered) "Login" else "Register",
+            onClick = { onAction(passwordSignInOrSignUp) },
             modifier = Modifier.fillMaxWidth(),
             enabled = uiState.isPasswordSignInEnabled
-        ) {
-            Text(
-                text = if (uiState.isAlreadyRegistered) "Login" else "Register"
-            )
-        }
+        )
 
         Spacer(modifier = Modifier.height(Spacings.medium))
         Row(
@@ -190,10 +196,10 @@ You may login to your existing account or create a new one if you don't have one
         Spacer(modifier = Modifier.height(Spacings.medium))
         TextDivider(text = "or")
         Spacer(modifier = Modifier.height(Spacings.medium))
+        val googleSignInOrSignUp = Action.Async.GoogleSignInOrSignUp
         SignInWithGoogleButton(
-            onButtonClick = {
-                onAction(Action.GoogleSignInOrSignUp)
-            },
+            isLoading = uiState.pendingActions.contains(googleSignInOrSignUp),
+            onButtonClick = { onAction(googleSignInOrSignUp) },
             isAlreadyRegistered = uiState.isAlreadyRegistered,
         )
     }

--- a/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/UiState.kt
+++ b/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/UiState.kt
@@ -1,5 +1,6 @@
 package edu.stanford.spezi.module.account.login
 
+import edu.stanford.spezi.core.design.action.PendingActions
 import edu.stanford.spezi.module.account.register.FieldState
 
 data class UiState(
@@ -11,6 +12,7 @@ data class UiState(
     val isFormValid: Boolean = false,
     val isAlreadyRegistered: Boolean = false,
     val isPasswordSignInEnabled: Boolean = false,
+    val pendingActions: PendingActions<Action.Async> = PendingActions(),
 )
 
 enum class TextFieldType {
@@ -21,8 +23,11 @@ sealed interface Action {
     data class TextFieldUpdate(val newValue: String, val type: TextFieldType) : Action
     data object TogglePasswordVisibility : Action
     data object NavigateToRegister : Action
-    data object GoogleSignInOrSignUp : Action
-    data object ForgotPassword : Action
-    data object PasswordSignInOrSignUp : Action
     data class SetIsAlreadyRegistered(val isAlreadyRegistered: Boolean) : Action
+
+    sealed interface Async : Action {
+        data object ForgotPassword : Async
+        data object GoogleSignInOrSignUp : Async
+        data object PasswordSignInOrSignUp : Async
+    }
 }

--- a/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/components/SignInWithGoogleButton.kt
+++ b/modules/account/src/main/kotlin/edu/stanford/spezi/module/account/login/components/SignInWithGoogleButton.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -13,6 +12,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import edu.stanford.spezi.core.design.R
+import edu.stanford.spezi.core.design.component.AsyncButton
 import edu.stanford.spezi.core.design.component.VerticalSpacer
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
@@ -20,9 +20,11 @@ import edu.stanford.spezi.core.design.theme.Spacings
 @Composable
 fun SignInWithGoogleButton(
     onButtonClick: () -> Unit,
+    isLoading: Boolean = false,
     isAlreadyRegistered: Boolean = false,
 ) {
-    Button(
+    AsyncButton(
+        isLoading = isLoading,
         onClick = {
             onButtonClick()
         },
@@ -46,5 +48,7 @@ fun SignInWithGoogleButtonPreview() {
         SignInWithGoogleButton(onButtonClick = {})
         VerticalSpacer()
         SignInWithGoogleButton(onButtonClick = {}, isAlreadyRegistered = true)
+        VerticalSpacer()
+        SignInWithGoogleButton(onButtonClick = {}, isLoading = true, isAlreadyRegistered = true)
     }
 }

--- a/modules/account/src/test/java/edu/stanford/spezi/module/account/login/LoginViewModelTest.kt
+++ b/modules/account/src/test/java/edu/stanford/spezi/module/account/login/LoginViewModelTest.kt
@@ -128,7 +128,7 @@ class LoginViewModelTest {
         coEvery { authenticationManager.signInWithGoogle() } returns Result.success(Unit)
 
         // when
-        loginViewModel.onAction(Action.GoogleSignInOrSignUp)
+        loginViewModel.onAction(Action.Async.GoogleSignInOrSignUp)
 
         // then
         verify { accountEvents.emit(event = AccountEvents.Event.SignInSuccess) }
@@ -143,7 +143,7 @@ class LoginViewModelTest {
         } returns Result.failure(Exception("Failed to sign in"))
 
         // when
-        loginViewModel.onAction(Action.GoogleSignInOrSignUp)
+        loginViewModel.onAction(Action.Async.GoogleSignInOrSignUp)
 
         // then
         verify { accountEvents.emit(event = AccountEvents.Event.SignInFailure) }
@@ -162,7 +162,7 @@ class LoginViewModelTest {
         )
 
         // when
-        loginViewModel.onAction(Action.GoogleSignInOrSignUp)
+        loginViewModel.onAction(Action.Async.GoogleSignInOrSignUp)
 
         // then
         verify { navigator.navigateTo(expectedEvent) }
@@ -187,7 +187,7 @@ class LoginViewModelTest {
     fun `given ForgotPassword action with valid email when onAction is called then send forgot password email`() =
         runTestUnconfined {
             // Given
-            val action = Action.ForgotPassword
+            val action = Action.Async.ForgotPassword
             val validEmail = "test@test.com"
             coEvery {
                 authenticationManager.sendForgotPasswordEmail(validEmail)
@@ -206,7 +206,7 @@ class LoginViewModelTest {
     fun `given ForgotPassword action with valid email when onAction is called, notifies message in case email sending failed`() =
         runTestUnconfined {
             // Given
-            val action = Action.ForgotPassword
+            val action = Action.Async.ForgotPassword
             val validEmail = "test@test.com"
             coEvery {
                 authenticationManager.sendForgotPasswordEmail(validEmail)
@@ -225,14 +225,14 @@ class LoginViewModelTest {
     fun `given ForgotPassword action with invalid email then notify message`() =
         runTestUnconfined {
             // Given
-            val action = Action.ForgotPassword
+            val action = Action.Async.ForgotPassword
             val email = "test@test.com"
             every { validator.isValidEmail(email) } returns FormValidator.Result.Invalid("invalid")
 
             // When
             listOf(
                 Action.TextFieldUpdate(email, TextFieldType.EMAIL),
-                Action.ForgotPassword,
+                action,
             ).forEach {
                 loginViewModel.onAction(action = it)
             }
@@ -257,7 +257,7 @@ class LoginViewModelTest {
         coEvery {
             authenticationManager.signIn(email = email, password = password)
         } returns Result.success(Unit)
-        val action = Action.PasswordSignInOrSignUp
+        val action = Action.Async.PasswordSignInOrSignUp
 
         // when
         loginViewModel.onAction(action)
@@ -279,7 +279,7 @@ class LoginViewModelTest {
         coEvery {
             authenticationManager.signIn(email = email, password = password)
         } returns Result.failure(Exception("Failure"))
-        val action = Action.PasswordSignInOrSignUp
+        val action = Action.Async.PasswordSignInOrSignUp
 
         // when
         loginViewModel.onAction(action)

--- a/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenSimulator.kt
+++ b/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenSimulator.kt
@@ -12,12 +12,12 @@ class EducationScreenSimulator(composeTestRule: ComposeTestRule) {
     private val retryButton =
         composeTestRule.onNodeWithIdentifier(EducationScreenTestIdentifier.RETRY_BUTTON)
 
-    private val progressBar =
-        composeTestRule.onNodeWithIdentifier(EducationScreenTestIdentifier.PROGRESS_BAR)
+    private val loadingRoot =
+        composeTestRule.onNodeWithIdentifier(EducationScreenTestIdentifier.LOADING_ROOT)
 
-    fun assertProgressBar() = this.progressBar.assertIsDisplayed()
+    fun assertLoading() = loadingRoot.assertIsDisplayed()
 
-    fun assertVideoSection() = this.videoSection.assertIsDisplayed()
+    fun assertVideoSection() = videoSection.assertIsDisplayed()
 
-    fun assertRetryButton() = this.retryButton.assertIsDisplayed()
+    fun assertRetryButton() = retryButton.assertIsDisplayed()
 }

--- a/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenTest.kt
+++ b/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenTest.kt
@@ -17,7 +17,7 @@ class EducationScreenTest {
     val composeTestRule = createAndroidComposeRule<ComposeContentActivity>()
 
     @Test
-    fun `education screen should display progress bar`() {
+    fun `education screen should display loading`() {
         composeTestRule.activity.setScreen {
             EducationScreen(
                 uiState = UiState.Loading,
@@ -26,7 +26,7 @@ class EducationScreenTest {
         }
 
         educationScreen {
-            assertProgressBar()
+            assertLoading()
         }
     }
 

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationScreen.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationScreen.kt
@@ -1,51 +1,32 @@
 package edu.stanford.spezi.modules.education.videos
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
-import coil.compose.AsyncImagePainter
-import coil.compose.SubcomposeAsyncImage
 import edu.stanford.spezi.core.design.component.Button
+import edu.stanford.spezi.core.design.component.RepeatingLazyColumn
 import edu.stanford.spezi.core.design.component.VerticalSpacer
 import edu.stanford.spezi.core.design.theme.Colors
-import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 import edu.stanford.spezi.core.utils.extensions.testIdentifier
 import edu.stanford.spezi.modules.education.videos.component.ExpandableVideoSection
-
-private const val IMAGE_HEIGHT = 200
-private const val ASPECT_16_9 = 16f / 9f
+import edu.stanford.spezi.modules.education.videos.component.LoadingVideoCard
 
 @Composable
 fun EducationScreen() {
@@ -58,96 +39,19 @@ fun EducationScreen() {
 }
 
 @Composable
-internal fun VideoItem(video: Video, onVideoClick: () -> Unit) {
-    Column(modifier = Modifier.padding(Spacings.small)) {
-        Text(
-            text = video.title,
-            style = MaterialTheme.typography.titleMedium,
-            modifier = Modifier
-                .padding(Spacings.small)
-        )
-
-        VerticalSpacer(height = Spacings.small)
-
-        SubcomposeAsyncImage(
-            modifier = Modifier
-                .clickable { onVideoClick() }
-                .height(IMAGE_HEIGHT.dp)
-                .padding(Spacings.small)
-                .fillMaxWidth(),
-            model = video.thumbnailUrl,
-
-            contentDescription = "Video thumbnail",
-        ) {
-            val state = painter.state
-            val painter = painter
-            if (state is AsyncImagePainter.State.Loading) {
-                Box(Modifier.matchParentSize()) {
-                    CircularProgressIndicator(
-                        Modifier
-                            .align(Alignment.Center)
-                    )
-                }
-            }
-
-            if (state is AsyncImagePainter.State.Error) {
-                Box(Modifier.matchParentSize()) {
-                    Text("Error loading image", Modifier.align(Alignment.Center))
-                }
-            }
-
-            if (state is AsyncImagePainter.State.Success) {
-                Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .aspectRatio(ASPECT_16_9)
-                        .border(Sizes.Border.medium, Colors.primary),
-                    contentAlignment = Alignment.Center
-                ) {
-                    Image(
-                        modifier = Modifier.fillMaxSize(),
-                        painter = painter,
-                        contentDescription = "Video thumbnail",
-                        contentScale = ContentScale.Crop,
-                    )
-                    Box(
-                        modifier = Modifier
-                            .align(Alignment.Center)
-                            .background(
-                                color = Colors.primary,
-                                shape = CircleShape
-                            )
-                            .padding(Spacings.medium)
-                    ) {
-                        Icon(
-                            imageVector = Icons.Default.PlayArrow,
-                            contentDescription = "Play button",
-                            modifier = Modifier
-                                .align(Alignment.Center)
-                                .size(Sizes.Icon.medium),
-                            tint = Colors.onPrimary
-                        )
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
 fun EducationScreen(
     uiState: UiState,
     onAction: (Action) -> Unit,
 ) {
     when (uiState) {
         is UiState.Loading -> {
-            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
-                CircularProgressIndicator(
-                    modifier = Modifier.testIdentifier(
-                        EducationScreenTestIdentifier.PROGRESS_BAR
-                    )
-                )
-            }
+            RepeatingLazyColumn(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(Spacings.medium)
+                    .testIdentifier(EducationScreenTestIdentifier.LOADING_ROOT),
+                content = { LoadingVideoCard() }
+            )
         }
 
         is UiState.Error -> {
@@ -170,43 +74,36 @@ fun EducationScreen(
                             .fillMaxWidth()
                             .testIdentifier(EducationScreenTestIdentifier.RETRY_BUTTON),
                         onClick = { onAction(Action.Retry) }) {
-                        Text(
-                            text = "Retry"
-                        )
+                        Text(text = "Retry")
                     }
                 }
             }
         }
 
         is UiState.Success -> {
-            val listState = rememberLazyListState()
-
-            Box(
+            LazyColumn(
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = Colors.background),
-                contentAlignment = Alignment.TopStart
+                    .padding(Spacings.medium)
             ) {
-                LazyColumn(state = listState, modifier = Modifier.fillMaxSize()) {
-                    items(uiState.data.videoSections) { videoSection ->
-                        ExpandableVideoSection(
-                            modifier = Modifier.testIdentifier(EducationScreenTestIdentifier.VIDEO_SECTION),
-                            title = videoSection.title,
-                            description = videoSection.description,
-                            videos = videoSection.videos,
-                            expandedStartValue = videoSection.isExpanded,
-                            onExpand = {
-                                onAction(Action.OnExpand(videoSection))
-                            },
-                            onActionClick = { video ->
-                                onAction(
-                                    Action.VideoSectionClicked(
-                                        video = video
-                                    )
+                items(uiState.data.videoSections) { videoSection ->
+                    ExpandableVideoSection(
+                        modifier = Modifier.testIdentifier(EducationScreenTestIdentifier.VIDEO_SECTION),
+                        title = videoSection.title,
+                        description = videoSection.description,
+                        videos = videoSection.videos,
+                        expandedStartValue = videoSection.isExpanded,
+                        onExpand = {
+                            onAction(Action.OnExpand(videoSection))
+                        },
+                        onActionClick = { video ->
+                            onAction(
+                                Action.VideoSectionClicked(
+                                    video = video
                                 )
-                            }
-                        )
-                    }
+                            )
+                        }
+                    )
                 }
             }
         }
@@ -268,5 +165,5 @@ private fun getVideoSection(): VideoSection {
 enum class EducationScreenTestIdentifier {
     RETRY_BUTTON,
     VIDEO_SECTION,
-    PROGRESS_BAR,
+    LOADING_ROOT,
 }

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/component/ExpandableVideoSection.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/component/ExpandableVideoSection.kt
@@ -3,18 +3,29 @@ package edu.stanford.spezi.modules.education.videos.component
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
 import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -26,18 +37,27 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImagePainter
+import coil.compose.SubcomposeAsyncImage
+import edu.stanford.spezi.core.design.component.RectangleShimmerEffect
+import edu.stanford.spezi.core.design.component.VerticalSpacer
+import edu.stanford.spezi.core.design.component.height
 import edu.stanford.spezi.core.design.theme.Colors
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
-import edu.stanford.spezi.core.design.theme.TextStyles
+import edu.stanford.spezi.core.design.theme.TextStyles.bodyMedium
 import edu.stanford.spezi.core.design.theme.TextStyles.titleLarge
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 import edu.stanford.spezi.core.design.theme.lighten
 import edu.stanford.spezi.modules.education.videos.Video
-import edu.stanford.spezi.modules.education.videos.VideoItem
+
+private const val IMAGE_HEIGHT = 200
+private const val ASPECT_16_9 = 16f / 9f
 
 @Composable
 internal fun SectionHeader(
@@ -75,15 +95,10 @@ internal fun ExpandableVideoSection(
 ) {
     var expanded by remember { mutableStateOf(expandedStartValue) }
 
-    ElevatedCard(
-        elevation = CardDefaults.cardElevation(defaultElevation = Sizes.Elevation.medium),
-        shape = RoundedCornerShape(Sizes.RoundedCorner.large),
-        colors = CardDefaults.cardColors(
-            containerColor = Colors.surface.lighten(),
-        ),
+    VideoElevatedCard(
         modifier = modifier
             .fillMaxWidth()
-            .padding(Spacings.small)
+            .padding(bottom = Spacings.medium)
             .clickable { expanded = !expanded }
     ) {
         Column(
@@ -100,7 +115,7 @@ internal fun ExpandableVideoSection(
 
             description?.let {
                 Text(
-                    style = TextStyles.bodyMedium,
+                    style = bodyMedium,
                     text = it,
                     modifier = Modifier
                         .fillMaxWidth()
@@ -126,6 +141,120 @@ internal fun ExpandableVideoSection(
             }
         }
     }
+}
+
+@Composable
+private fun VideoItem(video: Video, onVideoClick: () -> Unit) {
+    Column(modifier = Modifier.padding(Spacings.small)) {
+        Text(
+            text = video.title,
+            style = MaterialTheme.typography.titleMedium,
+            modifier = Modifier
+                .padding(Spacings.small)
+        )
+
+        VerticalSpacer(height = Spacings.small)
+
+        SubcomposeAsyncImage(
+            modifier = Modifier
+                .clickable { onVideoClick() }
+                .height(IMAGE_HEIGHT.dp)
+                .padding(Spacings.small)
+                .fillMaxWidth(),
+            model = video.thumbnailUrl,
+
+            contentDescription = "Video thumbnail",
+        ) {
+            val state = painter.state
+            val painter = painter
+            if (state is AsyncImagePainter.State.Loading) {
+                Box(Modifier.matchParentSize()) {
+                    CircularProgressIndicator(
+                        Modifier
+                            .align(Alignment.Center)
+                    )
+                }
+            }
+
+            if (state is AsyncImagePainter.State.Error) {
+                Box(Modifier.matchParentSize()) {
+                    Text("Error loading image", Modifier.align(Alignment.Center))
+                }
+            }
+
+            if (state is AsyncImagePainter.State.Success) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .aspectRatio(ASPECT_16_9)
+                        .border(Sizes.Border.medium, Colors.primary),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Image(
+                        modifier = Modifier.fillMaxSize(),
+                        painter = painter,
+                        contentDescription = "Video thumbnail",
+                        contentScale = ContentScale.Crop,
+                    )
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.Center)
+                            .background(
+                                color = Colors.primary,
+                                shape = CircleShape
+                            )
+                            .padding(Spacings.medium)
+                    ) {
+                        Icon(
+                            imageVector = Icons.Default.PlayArrow,
+                            contentDescription = "Play button",
+                            modifier = Modifier
+                                .align(Alignment.Center)
+                                .size(Sizes.Icon.medium),
+                            tint = Colors.onPrimary
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun LoadingVideoCard() {
+    VideoElevatedCard(modifier = Modifier.fillMaxWidth().padding(bottom = Spacings.medium)) {
+        Column(
+            modifier = Modifier.padding(Spacings.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacings.large + Spacings.medium)
+        ) {
+            RectangleShimmerEffect(
+                modifier = Modifier
+                    .fillMaxWidth(fraction = 0.8f)
+                    .height(titleLarge)
+            )
+            RectangleShimmerEffect(
+                modifier = Modifier
+                    .fillMaxWidth(fraction = 0.5f)
+                    .height(bodyMedium)
+            )
+        }
+    }
+}
+
+@Composable
+private fun VideoElevatedCard(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    ElevatedCard(
+        elevation = CardDefaults.cardElevation(defaultElevation = Sizes.Elevation.medium),
+        shape = RoundedCornerShape(Sizes.RoundedCorner.large),
+        colors = CardDefaults.cardColors(
+            containerColor = Colors.surface.lighten(),
+        ),
+        modifier = modifier,
+        content = content,
+    )
 }
 
 @Composable


### PR DESCRIPTION
# Loading states

Partially fixes #39 

## :gear: What was done
- Introduce AsyncButton and a mechanism in view models and compose to indicate pending async operations. Applied in all async operations of LoginScreen
- Introduce Shimmer effect
- Create placeholder loading cards with shimmer effect and apply in medications and educations screen
- Apply shimmer effect in vitalsdisplay in home screen
- Unify paddings and spacings in lazy columns and items in medication and education screens and the corresponding loading cards

Open / TODO:
- Unified no data (empty screen) and error screen with retry mechanism


**Recordings: Introduced longer delays and error states for demo purposes**


**Shimmer Effect**

https://github.com/user-attachments/assets/af6ac9cd-8f6a-42d4-a70d-5fcbdeeadbd2

**AsyncButton**

https://github.com/user-attachments/assets/92b6c703-e3a0-4b1b-8efb-1e1ddf53fd1d


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
