### PR TITLE
Task/issue 82

### DIFF
--- a/.github/workflows/build-test-analyze.yml
+++ b/.github/workflows/build-test-analyze.yml
@@ -115,7 +115,7 @@ jobs:
           profile: ${{ matrix.profile }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -wipe-data -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: false
           script: |
             sdkmanager --list
@@ -128,11 +128,9 @@ jobs:
           profile: ${{ matrix.profile }}
           arch: x86_64
           force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
+          emulator-options: -wipe-data -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: |
-            adb uninstall edu.stanford.spezi.core.design.test || true
-            bundle exec fastlane connectedCheck
+          script: bundle exec fastlane connectedCheck
       - name: Upload JaCoCo report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/.github/workflows/build-test-analyze.yml
+++ b/.github/workflows/build-test-analyze.yml
@@ -130,7 +130,9 @@ jobs:
           force-avd-creation: false
           emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
           disable-animations: true
-          script: bundle exec fastlane connectedCheck
+          script: |
+            adb uninstall edu.stanford.spezi.core.design.test || true
+            bundle exec fastlane connectedCheck
       - name: Upload JaCoCo report to Codecov
         uses: codecov/codecov-action@v4
         with:

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/AppNavigationTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/AppNavigationTest.kt
@@ -21,10 +21,12 @@ class AppNavigationTest {
     @get:Rule(order = 2)
     val composeTestRule = createAndroidComposeRule<MainActivity>()
 
-    @get:Rule
+    @get:Rule(order = 3)
     val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
         Manifest.permission.BLUETOOTH_CONNECT,
         Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
     )
 
     @Inject

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreenTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreenTest.kt
@@ -1,6 +1,8 @@
 package edu.stanford.bdh.engagehf.bluetooth.screen
 
+import android.Manifest
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.rule.GrantPermissionRule
 import dagger.hilt.android.testing.HiltAndroidRule
 import dagger.hilt.android.testing.HiltAndroidTest
 import edu.stanford.bdh.engagehf.R
@@ -19,6 +21,14 @@ class BluetoothScreenTest {
 
     @get:Rule
     val composeTestRule = createAndroidComposeRule<ComposeContentActivity>()
+
+    @get:Rule
+    val runtimePermissionRule: GrantPermissionRule = GrantPermissionRule.grant(
+        Manifest.permission.BLUETOOTH_CONNECT,
+        Manifest.permission.BLUETOOTH_SCAN,
+        Manifest.permission.ACCESS_COARSE_LOCATION,
+        Manifest.permission.ACCESS_FINE_LOCATION,
+    )
 
     @Before
     fun init() {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModel.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModel.kt
@@ -76,9 +76,9 @@ class BluetoothViewModel @Inject internal constructor(
                 logger.i { "Received BLEService event $event" }
                 when (event) {
                     BLEServiceEvent.BluetoothNotEnabled -> _events.emit(Event.EnableBluetooth)
-                    is BLEServiceEvent.MissingPermissions -> _events.emit(
-                        Event.RequestPermissions(event.permissions)
-                    )
+                    is BLEServiceEvent.MissingPermissions -> _uiState.update {
+                        it.copy(missingPermissions = event.permissions)
+                    }
 
                     is BLEServiceEvent.GenericError -> _uiState.update {
                         it.copy(bluetooth = BluetoothUiState.Error("Something went wrong!"))
@@ -202,6 +202,10 @@ class BluetoothViewModel @Inject internal constructor(
             is Action.ToggleExpand -> {
                 handleToggleExpandAction(action)
             }
+
+            is Action.PermissionGranted -> {
+                onPermissionGranted(action = action)
+            }
         }
     }
 
@@ -280,8 +284,13 @@ class BluetoothViewModel @Inject internal constructor(
         }
     }
 
+    private fun onPermissionGranted(action: Action.PermissionGranted) {
+        val missingPermissions = _uiState.value.missingPermissions.filter { it != action.permission }
+        _uiState.update { it.copy(missingPermissions = missingPermissions) }
+        bleService.start()
+    }
+
     interface Event {
         object EnableBluetooth : Event
-        data class RequestPermissions(val permissions: List<String>) : Event
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
@@ -160,7 +160,8 @@ class BluetoothUiStateMapper @Inject constructor(
                 status = OperationStatus.FAILURE,
                 date = null,
                 value = null,
-                unit = null
+                unit = null,
+                error = result.exceptionOrNull()?.message
             )
 
             successResult != null -> onSuccess(successResult)

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
@@ -8,4 +8,5 @@ sealed interface Action {
     data object DismissDialog : Action
     data class MessageItemClicked(val message: Message) : Action
     data class ToggleExpand(val message: Message) : Action
+    data class PermissionGranted(val permission: String) : Action
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/UiState.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/UiState.kt
@@ -14,5 +14,6 @@ data class UiState(
     ),
     val messages: List<Message> = emptyList(),
     val bluetooth: BluetoothUiState = BluetoothUiState.Idle,
+    val missingPermissions: List<String> = emptyList(),
     val measurementDialog: MeasurementDialogUiState = MeasurementDialogUiState(),
 )

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/screen/BluetoothScreen.kt
@@ -2,6 +2,8 @@ package edu.stanford.bdh.engagehf.bluetooth.screen
 
 import android.app.Activity
 import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,7 +25,6 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.compose.ui.unit.dp
-import androidx.core.app.ActivityCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import edu.stanford.bdh.engagehf.R
 import edu.stanford.bdh.engagehf.bluetooth.BluetoothViewModel
@@ -49,8 +50,6 @@ import edu.stanford.spezi.core.utils.extensions.testIdentifier
 import kotlinx.coroutines.flow.Flow
 import java.time.ZonedDateTime
 
-private const val BOX_CONSTRAINT_HEIGHT = 0.35f
-
 @Composable
 fun BluetoothScreen() {
     val viewModel = hiltViewModel<BluetoothViewModel>()
@@ -67,6 +66,11 @@ private fun BluetoothScreen(
     uiState: UiState,
     onAction: (Action) -> Unit,
 ) {
+    PermissionRequester(
+        permissions = uiState.missingPermissions,
+        onGranted = { onAction(Action.PermissionGranted(permission = it)) }
+    )
+
     LazyColumn(
         modifier = Modifier
             .testIdentifier(BluetoothScreenTestIdentifier.ROOT)
@@ -201,20 +205,27 @@ private fun BluetoothEvents(events: Flow<BluetoothViewModel.Event>) {
     LaunchedEffect(key1 = Unit) {
         events.collect { event ->
             when (event) {
-                is BluetoothViewModel.Event.RequestPermissions -> {
-                    ActivityCompat.requestPermissions(
-                        activity,
-                        event.permissions.toTypedArray(),
-                        1
-                    )
-                }
-
                 is BluetoothViewModel.Event.EnableBluetooth -> {
                     Toast.makeText(activity, "Bluetooth is not enabled", Toast.LENGTH_LONG)
                         .show()
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun PermissionRequester(
+    permissions: List<String>,
+    onGranted: (String) -> Unit,
+) {
+    val permission = permissions.firstOrNull() ?: return
+    val launcher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { granted -> if (granted) onGranted(permission) }
+
+    LaunchedEffect(key1 = permission) {
+        launcher.launch(permission)
     }
 }
 

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModelTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/BluetoothViewModelTest.kt
@@ -169,7 +169,7 @@ class BluetoothViewModelTest {
         bleServiceEvents.emit(event)
 
         // then
-        assertEvent(event = BluetoothViewModel.Event.RequestPermissions(permissions))
+        assertThat(bluetoothViewModel.uiState.value.missingPermissions).isEqualTo(permissions)
     }
 
     @Test
@@ -511,6 +511,22 @@ class BluetoothViewModelTest {
         assertThat(
             bluetoothViewModel.uiState.value.messages.first().isExpanded
         ).isEqualTo(isExpanded.not())
+    }
+
+    @Test
+    fun `it should handle permission granted action correctly`() = runTestUnconfined {
+        // given
+        val permissions = listOf("permission1")
+        val event = BLEServiceEvent.MissingPermissions(permissions)
+        createViewModel()
+        bleServiceEvents.emit(event)
+
+        // when
+        bluetoothViewModel.onAction(Action.PermissionGranted(permission = permissions.first()))
+
+        // then
+        assertThat(bluetoothViewModel.uiState.value.missingPermissions).isEmpty()
+        verify(exactly = 2) { bleService.start() }
     }
 
     private fun assertBluetothUiState(state: BluetoothUiState) {

--- a/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
+++ b/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
@@ -182,6 +182,8 @@ internal class BLEServiceImpl @Inject constructor(
         val REQUIRED_PERMISSIONS = listOf(
             Manifest.permission.BLUETOOTH_CONNECT,
             Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
         )
     }
 }

--- a/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
+++ b/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
@@ -107,6 +107,8 @@ class BLEServiceTest {
         val expectedPermissions = listOf(
             Manifest.permission.BLUETOOTH_CONNECT,
             Manifest.permission.BLUETOOTH_SCAN,
+            Manifest.permission.ACCESS_COARSE_LOCATION,
+            Manifest.permission.ACCESS_FINE_LOCATION,
         )
 
         // when


### PR DESCRIPTION
# Missing Bluetooth permission

## :recycle: Current situation & Problem
Fixes #82 

We were not requesting location related permissions needed for Bluetooth connection and not restarting bluetooth service on permission change.

- Pointing to #94 branch
- Add missing permission and restart bluetooth service on permission change

**Recording** (hardcoded Home screen to avoid authentication step for demo purposes)

https://github.com/user-attachments/assets/baa138a9-7e25-4f26-b308-77ac5ad99245




By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
