### PR TITLE
fix parsing of year

### DIFF
--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapper.kt
@@ -36,11 +36,15 @@ internal class BloodPressureMapper @Inject constructor() : MeasurementMapper.Chi
         characteristic: BluetoothGattCharacteristic?,
         data: ByteArray,
     ): Measurement? {
-        return if (recognises(characteristic).not()) null else runCatching {
-            interpretBloodPressureMeasurement(
-                data = data
-            )
-        }.getOrNull()
+        return if (recognises(characteristic).not()) {
+            null
+        } else {
+            runCatching {
+                interpretBloodPressureMeasurement(
+                    data = data
+                )
+            }.getOrNull()
+        }
     }
 
     private fun interpretBloodPressureMeasurement(data: ByteArray): Measurement.BloodPressure {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapper.kt
@@ -1,4 +1,5 @@
 @file:Suppress("MagicNumber")
+
 package edu.stanford.bdh.engagehf.bluetooth.service.mapper
 
 import android.bluetooth.BluetoothGattCharacteristic
@@ -19,7 +20,8 @@ internal class BloodPressureMapper @Inject constructor() : MeasurementMapper.Chi
      */
     override fun recognises(characteristic: BluetoothGattCharacteristic?): Boolean {
         return with(BLEServiceType.BLOOD_PRESSURE) {
-            characteristic?.let { service == it.service.uuid && this.characteristic == it.uuid } ?: false
+            characteristic?.let { service == it.service.uuid && this.characteristic == it.uuid }
+                ?: false
         }
     }
 
@@ -30,8 +32,15 @@ internal class BloodPressureMapper @Inject constructor() : MeasurementMapper.Chi
      * @param data The byte array representing the data of the characteristic.
      * @return The blood pressure measurement, or null if the characteristic is not recognized or mapping fails.
      */
-    override suspend fun map(characteristic: BluetoothGattCharacteristic?, data: ByteArray): Measurement? {
-        return if (recognises(characteristic).not()) null else runCatching { interpretBloodPressureMeasurement(data = data) }.getOrNull()
+    override suspend fun map(
+        characteristic: BluetoothGattCharacteristic?,
+        data: ByteArray,
+    ): Measurement? {
+        return if (recognises(characteristic).not()) null else runCatching {
+            interpretBloodPressureMeasurement(
+                data = data
+            )
+        }.getOrNull()
     }
 
     private fun interpretBloodPressureMeasurement(data: ByteArray): Measurement.BloodPressure {
@@ -46,7 +55,7 @@ internal class BloodPressureMapper @Inject constructor() : MeasurementMapper.Chi
         val systolic = (data[1].toInt() and 0xFF).toFloat()
         val diastolic = (data[3].toInt() and 0xFF).toFloat()
         val meanArterialPressure = (data[5].toInt() and 0xFF).toFloat()
-        val timestampYear = (data[7].toInt() and 0xFF)
+        val timestampYear = (data[7].toInt() and 0xFF) or ((data[8].toInt() and 0xFF) shl 8)
         val timestampMonth = (data[9].toInt() and 0xFF)
         val timestampDay = (data[10].toInt() and 0xFF)
         val timeStampHour = (data[11].toInt() and 0xFF)

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/service/mapper/BloodPressureMapperTest.kt
@@ -48,49 +48,50 @@ class BloodPressureMapperTest {
     }
 
     @Test
-    fun `it should map characteristic and data to blood pressure measurement`() = runTestUnconfined {
-        // given
-        val sut = mapper
-        val data = byteArrayOf(
-            0b00101111, // Flags: bloodPressureUnitsFlag, timeStampFlag, pulseRateFlag, userIdFlag, measurementStatusFlag
-            120, // Systolic
-            0,
-            80, // Diastolic
-            0,
-            70, // Mean Arterial Pressure
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-            0,
-        )
-
-        // when
-        val result = sut.map(characteristic, data) as Measurement.BloodPressure
-
-        // then
-        with(result) {
-            val expectedFlags = Measurement.BloodPressure.Flags(
-                bloodPressureUnitsFlag = true,
-                timeStampFlag = true,
-                pulseRateFlag = true,
-                userIdFlag = true,
-                measurementStatusFlag = true
+    fun `it should map characteristic and data to blood pressure measurement`() =
+        runTestUnconfined {
+            // given
+            val sut = mapper
+            val data = byteArrayOf(
+                0b00101111, // Flags: bloodPressureUnitsFlag, timeStampFlag, pulseRateFlag, userIdFlag, measurementStatusFlag
+                120, // Systolic
+                0,
+                80, // Diastolic
+                0,
+                70, // Mean Arterial Pressure
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
             )
-            assertThat(flags).isEqualTo(expectedFlags)
-            assertThat(systolic).isEqualTo(120.0f)
-            assertThat(diastolic).isEqualTo(80.0f)
-            assertThat(meanArterialPressure).isEqualTo(70.0f)
+
+            // when
+            val result = sut.map(characteristic, data) as Measurement.BloodPressure
+
+            // then
+            with(result) {
+                val expectedFlags = Measurement.BloodPressure.Flags(
+                    bloodPressureUnitsFlag = true,
+                    timeStampFlag = true,
+                    pulseRateFlag = true,
+                    userIdFlag = true,
+                    measurementStatusFlag = true
+                )
+                assertThat(flags).isEqualTo(expectedFlags)
+                assertThat(systolic).isEqualTo(120.0f)
+                assertThat(diastolic).isEqualTo(80.0f)
+                assertThat(meanArterialPressure).isEqualTo(70.0f)
+            }
         }
-    }
 
     @Test
     fun `it should return null when characteristic is not recognised`() = runTestUnconfined {
@@ -117,5 +118,24 @@ class BloodPressureMapperTest {
 
         // then
         assertThat(result).isNull()
+    }
+
+    @Test
+    fun `it should return correct date when map from byteArray`() = runTestUnconfined {
+        // given
+        val data = byteArrayOf(30, -126, 0, 83, 0, 98, 0, -24, 7, 9, 30, 22, 11, 23, 80, 0, 1, 0, 0)
+
+        // when
+        val result = mapper.map(characteristic, data) as Measurement.BloodPressure
+
+        // then
+        with(result) {
+            assertThat(timestampYear).isEqualTo(2024)
+            assertThat(timestampMonth).isEqualTo(9)
+            assertThat(timestampDay).isEqualTo(30)
+            assertThat(timeStampHour).isEqualTo(22)
+            assertThat(timeStampMinute).isEqualTo(11)
+            assertThat(timeStampSecond).isEqualTo(23)
+        }
     }
 }


### PR DESCRIPTION
# *fix parsing of year*

## :recycle: Current situation & Problem
Timeyear parsing didn't seem to work correctly.


## :gear: Release Notes 
Expand timestampYear to 16 bits by combining data[7] and data[8] for accurate year representation

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
