### PR TITLE
Adding Sections to Meds Page + Change Medication Status Colors + add a key

### DIFF
--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
@@ -13,7 +13,13 @@ class MedicationScreenTest {
 
     @Test
     fun `it should display the success correctly`() {
-        setUiState(MedicationUiState.Success(getMedicationCardUiModels()))
+        setUiState(
+            MedicationUiState.Success(
+                Medications(getMedicationCardUiModels(), true),
+                Medications(getMedicationCardUiModels(), true),
+                true,
+            )
+        )
         medicationScreen {
             assertSuccessIsDisplayed()
         }
@@ -81,7 +87,7 @@ class MedicationScreenTest {
                 progress = 0.234f,
             ),
             isExpanded = true,
-            statusColor = MedicationColor.GREY,
+            statusColor = MedicationColor.BLUE,
             statusIconResId = R.drawable.ic_check,
             videoPath = "/videoSections/1/videos/1"
         )

--- a/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
+++ b/app/src/androidTest/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreenTest.kt
@@ -15,9 +15,15 @@ class MedicationScreenTest {
     fun `it should display the success correctly`() {
         setUiState(
             MedicationUiState.Success(
-                Medications(getMedicationCardUiModels(), true),
-                Medications(getMedicationCardUiModels(), true),
-                true,
+                medicationsTaking = Medications(
+                    medications = getMedicationCardUiModels(),
+                    expanded = true
+                ),
+                medicationsThatMayHelp = Medications(
+                    medications = getMedicationCardUiModels(),
+                    expanded = true
+                ),
+                colorKeyExpanded = true,
             )
         )
         medicationScreen {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/ColorKey.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/ColorKey.kt
@@ -1,0 +1,81 @@
+package edu.stanford.bdh.engagehf.medication.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import edu.stanford.bdh.engagehf.R
+import edu.stanford.bdh.engagehf.medication.ui.MedicationColor
+import edu.stanford.spezi.core.design.component.DefaultElevatedCard
+import edu.stanford.spezi.core.design.theme.Sizes
+import edu.stanford.spezi.core.design.theme.Spacings
+import edu.stanford.spezi.core.design.theme.SpeziTheme
+import edu.stanford.spezi.core.design.theme.ThemePreviews
+
+@Composable
+fun ColorKey(
+    modifier: Modifier = Modifier,
+) {
+    DefaultElevatedCard(
+        modifier = modifier
+            .padding(bottom = Spacings.medium),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(Spacings.medium),
+            verticalArrangement = Arrangement.spacedBy(Spacings.small),
+        ) {
+            MedicationColor.entries.forEach {
+                ColorKeyRow(color = it)
+            }
+        }
+    }
+}
+
+@Composable
+fun ColorKeyRow(color: MedicationColor) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(Sizes.Icon.medium)
+                .background(
+                    color.value.copy(alpha = MEDICATION_ICON_ALPHA_COLOR_FACTOR),
+                    shape = CircleShape
+                )
+                .padding(Spacings.small),
+        )
+        Spacer(modifier = Modifier.width(Spacings.small))
+        Text(
+            text = when (color) {
+                MedicationColor.GREEN_SUCCESS -> stringResource(R.string.on_target_dose_that_best_helps_your_heart)
+                MedicationColor.YELLOW -> stringResource(R.string.on_medication_but_may_benefit_from_a_higher_dose)
+                MedicationColor.BLUE -> stringResource(R.string.not_on_this_medication_that_may_help_your_heart)
+            },
+            overflow = TextOverflow.Clip,
+        )
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun ColorKeyPreview() {
+    SpeziTheme(isPreview = true) {
+        ColorKey()
+    }
+}

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
@@ -38,6 +38,8 @@ import edu.stanford.spezi.core.design.theme.TextStyles
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 import edu.stanford.spezi.core.utils.extensions.testIdentifier
 
+private const val LOADING_ITEM_COUNT = 3
+
 @Composable
 fun MedicationCard(
     modifier: Modifier = Modifier,
@@ -144,30 +146,49 @@ fun MedicationCard(
 }
 
 @Composable
-fun LoadingMedicationCard() {
-    DefaultElevatedCard(modifier = Modifier.padding(bottom = Spacings.medium)) {
-        Row(
+fun LoadingMedicationSection() {
+    Column {
+        RectangleShimmerEffect(
             modifier = Modifier
-                .fillMaxWidth()
-                .padding(Spacings.medium),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            CircleShimmerEffect(modifier = Modifier.size(Sizes.Icon.medium))
+                .padding(vertical = Spacings.medium)
+                .fillMaxWidth(fraction = 0.7f)
+                .height(textStyle = TextStyles.titleMedium) // section header, same height as the text style
+        )
 
-            Column(modifier = Modifier.padding(Spacings.small)) {
-                RectangleShimmerEffect(
+        repeat(LOADING_ITEM_COUNT) {
+            DefaultElevatedCard(modifier = Modifier.padding(bottom = Spacings.medium)) {
+                Row(
                     modifier = Modifier
-                        .fillMaxWidth(fraction = 0.8f)
-                        .height(textStyle = TextStyles.titleLarge)
-                )
-                VerticalSpacer()
-                RectangleShimmerEffect(
-                    modifier = Modifier
-                        .fillMaxWidth(fraction = 0.5f)
-                        .height(textStyle = TextStyles.titleSmall)
-                )
+                        .fillMaxWidth()
+                        .padding(Spacings.medium),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    CircleShimmerEffect(modifier = Modifier.size(Sizes.Icon.medium))
+
+                    Column(modifier = Modifier.padding(Spacings.small)) {
+                        RectangleShimmerEffect(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction = 0.8f)
+                                .height(textStyle = TextStyles.titleLarge)
+                        )
+                        VerticalSpacer()
+                        RectangleShimmerEffect(
+                            modifier = Modifier
+                                .fillMaxWidth(fraction = 0.5f)
+                                .height(textStyle = TextStyles.titleSmall)
+                        )
+                    }
+                }
             }
         }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun LoadingMedicationSectionPreview() {
+    SpeziTheme(isPreview = true) {
+        LoadingMedicationSection()
     }
 }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCardModelsProvider.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCardModelsProvider.kt
@@ -12,7 +12,7 @@ class MedicationCardModelsProvider : PreviewParameterProvider<MedicationCardUiMo
         getMedicationCardUiModel(MedicationColor.GREEN_SUCCESS, isExpanded = true),
         getMedicationCardUiModel(color = MedicationColor.GREEN_SUCCESS),
         getMedicationCardUiModel(color = MedicationColor.YELLOW),
-        getMedicationCardUiModel(color = MedicationColor.GREY),
+        getMedicationCardUiModel(color = MedicationColor.BLUE),
     )
 }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
@@ -1,14 +1,24 @@
 package edu.stanford.bdh.engagehf.medication.components
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import edu.stanford.bdh.engagehf.R
 import edu.stanford.bdh.engagehf.medication.ui.MedicationCardUiModel
 import edu.stanford.bdh.engagehf.medication.ui.MedicationUiState
 import edu.stanford.bdh.engagehf.medication.ui.MedicationViewModel
+import edu.stanford.bdh.engagehf.medication.ui.Medications
+import edu.stanford.spezi.core.design.component.CenteredBoxContent
+import edu.stanford.spezi.core.design.component.DefaultElevatedCard
+import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
+import edu.stanford.spezi.core.design.theme.TextStyles
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 
 @Composable
@@ -18,8 +28,68 @@ fun MedicationList(
     onAction: (MedicationViewModel.Action) -> Unit,
 ) {
     LazyColumn(modifier = modifier) {
-        items(uiState.uiModels) {
-            MedicationCard(model = it, onAction = onAction)
+        item {
+            SectionHeader(
+                title = stringResource(R.string.medication_you_are_taking),
+                onToggleExpand = {
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_TAKING))
+                }
+            )
+        }
+        medicationItems(
+            isExpanded = uiState.medicationsTaking.expanded,
+            medications = uiState.medicationsTaking.medications,
+            onAction = onAction,
+        )
+        item {
+            SectionHeader(
+                title = stringResource(R.string.medications_that_may_help),
+                onToggleExpand = {
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP))
+                }
+            )
+        }
+        medicationItems(
+            isExpanded = uiState.medicationsThatMayHelp.expanded,
+            medications = uiState.medicationsThatMayHelp.medications,
+            onAction = onAction,
+        )
+        item {
+            SectionHeader(
+                title = stringResource(R.string.color_key),
+                onToggleExpand = {
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.COLOR_KEY))
+                }
+            )
+        }
+        if (uiState.colorKeyExpanded) {
+            item { ColorKey() }
+        }
+    }
+}
+
+fun LazyListScope.medicationItems(
+    isExpanded: Boolean,
+    medications: List<MedicationCardUiModel>,
+    onAction: (MedicationViewModel.Action) -> Unit,
+) {
+    if (isExpanded) {
+        if (medications.isEmpty()) {
+            item {
+                DefaultElevatedCard {
+                    CenteredBoxContent {
+                        Text(
+                            modifier = Modifier.padding(Spacings.medium),
+                            text = stringResource(R.string.no_medications_to_show),
+                            style = TextStyles.bodyMedium,
+                        )
+                    }
+                }
+            }
+        } else {
+            items(medications) { model ->
+                MedicationCard(model = model, onAction = onAction)
+            }
         }
     }
 }
@@ -27,9 +97,13 @@ fun MedicationList(
 @ThemePreviews
 @Composable
 private fun MedicationListPreview(
-    @PreviewParameter(MedicationCardModelsProvider::class) uiModels: List<MedicationCardUiModel>,
+    @PreviewParameter(MedicationCardModelsProvider::class) uiModels: MedicationCardUiModel,
 ) {
-    val uiState = MedicationUiState.Success(uiModels = uiModels)
+    val uiState = MedicationUiState.Success(
+        medicationsTaking = Medications(listOf(uiModels), true),
+        medicationsThatMayHelp = Medications(emptyList(), true),
+        colorKeyExpanded = true,
+    )
     SpeziTheme {
         MedicationList(uiState = uiState, onAction = { })
     }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationList.kt
@@ -32,7 +32,7 @@ fun MedicationList(
             SectionHeader(
                 title = stringResource(R.string.medication_you_are_taking),
                 onToggleExpand = {
-                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_TAKING))
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.Section.MEDICATIONS_TAKING))
                 }
             )
         }
@@ -45,7 +45,7 @@ fun MedicationList(
             SectionHeader(
                 title = stringResource(R.string.medications_that_may_help),
                 onToggleExpand = {
-                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP))
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.Section.MEDICATIONS_THAT_MAY_HELP))
                 }
             )
         }
@@ -58,7 +58,7 @@ fun MedicationList(
             SectionHeader(
                 title = stringResource(R.string.color_key),
                 onToggleExpand = {
-                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.COLOR_KEY))
+                    onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.Section.COLOR_KEY))
                 }
             )
         }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationProgressBar.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationProgressBar.kt
@@ -17,12 +17,14 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import edu.stanford.bdh.engagehf.R
-import edu.stanford.bdh.engagehf.medication.ui.MedicationColor
 import edu.stanford.spezi.core.design.component.VerticalSpacer
 import edu.stanford.spezi.core.design.theme.Sizes
 import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.ThemePreviews
+
+private const val PROGRESS_GREEN_HEX = 0xFF00796B
+private val PROGRESS_GREEN = Color(PROGRESS_GREEN_HEX)
 
 @Composable
 fun MedicationProgressBar(progress: Float) {
@@ -37,7 +39,7 @@ fun MedicationProgressBar(progress: Float) {
                 modifier = Modifier
                     .fillMaxHeight()
                     .fillMaxWidth(progress)
-                    .background(MedicationColor.GREEN_PROGRESS.value, RoundedCornerShape(Sizes.RoundedCorner.large))
+                    .background(PROGRESS_GREEN, RoundedCornerShape(Sizes.RoundedCorner.large))
             )
         }
         VerticalSpacer(height = Spacings.extraSmall)
@@ -47,11 +49,11 @@ fun MedicationProgressBar(progress: Float) {
         ) {
             Text(
                 text = stringResource(R.string.medication_progress_bar_current),
-                color = MedicationColor.GREEN_PROGRESS.value,
+                color = PROGRESS_GREEN,
             )
             Text(
                 text = stringResource(R.string.medication_progress_bar_target),
-                color = MedicationColor.GREY.value,
+                color = Color.LightGray,
             )
         }
     }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationSectionHeader.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationSectionHeader.kt
@@ -1,0 +1,53 @@
+package edu.stanford.bdh.engagehf.medication.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import edu.stanford.spezi.core.design.theme.Spacings
+import edu.stanford.spezi.core.design.theme.TextStyles
+import edu.stanford.spezi.core.design.theme.ThemePreviews
+
+@Composable
+fun SectionHeader(
+    title: String,
+    onToggleExpand: () -> Unit,
+) {
+    Row(
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            modifier = Modifier.padding(start = Spacings.medium),
+            text = title,
+            style = TextStyles.titleMedium,
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        IconButton(
+            modifier = Modifier.padding(end = Spacings.medium),
+            onClick = onToggleExpand
+        ) {
+            Icon(
+                Icons.Default.ArrowDropDown,
+                contentDescription = null,
+            )
+        }
+    }
+}
+
+@ThemePreviews
+@Composable
+private fun SectionHeaderPreview() {
+    SectionHeader(
+        title = "Section Header",
+        onToggleExpand = {},
+    )
+}

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationStatusIcon.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationStatusIcon.kt
@@ -17,13 +17,18 @@ import edu.stanford.spezi.core.design.theme.Spacings
 import edu.stanford.spezi.core.design.theme.SpeziTheme
 import edu.stanford.spezi.core.design.theme.ThemePreviews
 
+const val MEDICATION_ICON_ALPHA_COLOR_FACTOR = 0.3f
+
 @Composable
 fun MedicationStatusIcon(model: MedicationCardUiModel) {
     val backgroundColor = model.statusColor.value
     Box(
         modifier = Modifier
             .size(Sizes.Icon.medium)
-            .background(backgroundColor.copy(alpha = 0.1f), shape = CircleShape)
+            .background(
+                backgroundColor.copy(alpha = MEDICATION_ICON_ALPHA_COLOR_FACTOR),
+                shape = CircleShape
+            )
             .padding(Spacings.small),
         contentAlignment = Alignment.Center
     ) {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
@@ -88,11 +88,19 @@ private class UiStateProvider : PreviewParameterProvider<MedicationUiState> {
         MedicationUiState.Error(message = "An error occurred"),
         MedicationUiState.NoData(message = "No message recommendations"),
         MedicationUiState.Success(
-            uiModels = listOf(
-                getMedicationCardUiModel(MedicationColor.YELLOW, true),
-                getMedicationCardUiModel(MedicationColor.GREEN_SUCCESS, true),
-                getMedicationCardUiModel(MedicationColor.GREY),
-            )
+            medicationsTaking = Medications(
+                listOf(
+                    getMedicationCardUiModel(MedicationColor.YELLOW, true),
+                    getMedicationCardUiModel(MedicationColor.GREEN_SUCCESS, true),
+                ), expanded = true
+            ),
+            medicationsThatMayHelp = Medications(
+                listOf(
+                    getMedicationCardUiModel(MedicationColor.BLUE),
+                ),
+                expanded = false
+            ),
+            colorKeyExpanded = false
         )
     )
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationScreen.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
 import androidx.hilt.navigation.compose.hiltViewModel
-import edu.stanford.bdh.engagehf.medication.components.LoadingMedicationCard
+import edu.stanford.bdh.engagehf.medication.components.LoadingMedicationSection
 import edu.stanford.bdh.engagehf.medication.components.MedicationList
 import edu.stanford.bdh.engagehf.medication.components.getMedicationCardUiModel
 import edu.stanford.spezi.core.design.component.CenteredBoxContent
@@ -65,7 +65,8 @@ fun MedicationScreen(
                     .fillMaxSize()
                     .padding(Spacings.medium)
                     .testIdentifier(MedicationScreenTestIdentifier.LOADING),
-                content = { LoadingMedicationCard() }
+                itemCount = 2,
+                content = { LoadingMedicationSection() }
             )
         }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiState.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiState.kt
@@ -8,9 +8,19 @@ import androidx.compose.ui.graphics.Color
 sealed interface MedicationUiState {
     data object Loading : MedicationUiState
     data class NoData(val message: String) : MedicationUiState
-    data class Success(val uiModels: List<MedicationCardUiModel>) : MedicationUiState
+    data class Success(
+        val medicationsTaking: Medications,
+        val medicationsThatMayHelp: Medications,
+        val colorKeyExpanded: Boolean,
+    ) : MedicationUiState
+
     data class Error(val message: String) : MedicationUiState
 }
+
+data class Medications(
+    val medications: List<MedicationCardUiModel>,
+    val expanded: Boolean,
+)
 
 /**
  * Represents the ui model displayed in a medication card
@@ -44,7 +54,6 @@ data class DosageRowInfoData(
 @Suppress("MagicNumber")
 enum class MedicationColor(val value: Color) {
     GREEN_SUCCESS(value = Color(0xFF34C759)),
-    GREEN_PROGRESS(value = Color(0xFF00796B)),
     YELLOW(value = Color(0xFFFFCC00)),
-    GREY(value = Color(0xFF53565A)),
+    BLUE(value = Color(0xFF677FF0)),
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
@@ -28,7 +28,8 @@ class MedicationUiStateMapper @Inject constructor(
                 ),
                 medicationsThatMayHelp = Medications(medications =
                 recommendations.filter { it.type == MedicationRecommendationType.NOT_STARTED }
-                    .sortedByDescending { it.type.priority }.map { map(it) },
+                    .sortedByDescending { it.type.priority }
+                    .map { map(it) },
                     expanded = false
                 ),
                 colorKeyExpanded = false

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
@@ -22,15 +22,17 @@ class MedicationUiStateMapper @Inject constructor(
         } else {
             MedicationUiState.Success(
                 medicationsTaking =
-                Medications(medications = recommendations.filter { it.type != MedicationRecommendationType.NOT_STARTED }
-                    .sortedByDescending { it.type.priority }.map { map(it) },
-                    expanded = true
+                Medications(
+                    medications = recommendations.filter { it.type != MedicationRecommendationType.NOT_STARTED }
+                        .sortedByDescending { it.type.priority }
+                        .map { map(it) },
+                    expanded = true,
                 ),
-                medicationsThatMayHelp = Medications(medications =
-                recommendations.filter { it.type == MedicationRecommendationType.NOT_STARTED }
-                    .sortedByDescending { it.type.priority }
-                    .map { map(it) },
-                    expanded = false
+                medicationsThatMayHelp = Medications(
+                    medications = recommendations.filter { it.type == MedicationRecommendationType.NOT_STARTED }
+                        .sortedByDescending { it.type.priority }
+                        .map { map(it) },
+                    expanded = false,
                 ),
                 colorKeyExpanded = false
             )

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
@@ -54,11 +54,11 @@ class MedicationUiStateMapper @Inject constructor(
     }
 
     fun toggleItemExpand(
-        section: MedicationViewModel.SECTION,
+        section: MedicationViewModel.Section,
         uiState: MedicationUiState.Success,
     ): MedicationUiState {
         return when (section) {
-            MedicationViewModel.SECTION.MEDICATIONS_TAKING -> {
+            MedicationViewModel.Section.MEDICATIONS_TAKING -> {
                 uiState.copy(
                     medicationsTaking = uiState.medicationsTaking.copy(
                         expanded = !uiState.medicationsTaking.expanded
@@ -66,7 +66,7 @@ class MedicationUiStateMapper @Inject constructor(
                 )
             }
 
-            MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP -> {
+            MedicationViewModel.Section.MEDICATIONS_THAT_MAY_HELP -> {
                 uiState.copy(
                     medicationsThatMayHelp = uiState.medicationsThatMayHelp.copy(
                         expanded = !uiState.medicationsThatMayHelp.expanded
@@ -74,7 +74,7 @@ class MedicationUiStateMapper @Inject constructor(
                 )
             }
 
-            MedicationViewModel.SECTION.COLOR_KEY -> {
+            MedicationViewModel.Section.COLOR_KEY -> {
                 uiState.copy(colorKeyExpanded = !uiState.colorKeyExpanded)
             }
         }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapper.kt
@@ -21,9 +21,18 @@ class MedicationUiStateMapper @Inject constructor(
             )
         } else {
             MedicationUiState.Success(
-                uiModels = recommendations
-                    .sortedByDescending { it.type.priority }
-                    .map { map(it) })
+                medicationsTaking =
+                Medications(medications = recommendations.filter { it.type != MedicationRecommendationType.NOT_STARTED }
+                    .sortedByDescending { it.type.priority }.map { map(it) },
+                    expanded = true
+                ),
+                medicationsThatMayHelp = Medications(medications =
+                recommendations.filter { it.type == MedicationRecommendationType.NOT_STARTED }
+                    .sortedByDescending { it.type.priority }.map { map(it) },
+                    expanded = false
+                ),
+                colorKeyExpanded = false
+            )
         }
     }
 
@@ -41,20 +50,63 @@ class MedicationUiStateMapper @Inject constructor(
         )
     }
 
+    fun toggleItemExpand(
+        section: MedicationViewModel.SECTION,
+        uiState: MedicationUiState.Success,
+    ): MedicationUiState {
+        return when (section) {
+            MedicationViewModel.SECTION.MEDICATIONS_TAKING -> {
+                uiState.copy(
+                    medicationsTaking = uiState.medicationsTaking.copy(
+                        expanded = !uiState.medicationsTaking.expanded
+                    )
+                )
+            }
+
+            MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP -> {
+                uiState.copy(
+                    medicationsThatMayHelp = uiState.medicationsThatMayHelp.copy(
+                        expanded = !uiState.medicationsThatMayHelp.expanded
+                    )
+                )
+            }
+
+            MedicationViewModel.SECTION.COLOR_KEY -> {
+                uiState.copy(colorKeyExpanded = !uiState.colorKeyExpanded)
+            }
+        }
+    }
+
     fun expandMedication(
         medicationId: String,
         uiState: MedicationUiState,
     ): MedicationUiState {
         return if (uiState is MedicationUiState.Success) {
-            val newValue = uiState.uiModels
-                .map { model ->
-                    if (model.id == medicationId) {
-                        model.copy(isExpanded = model.isExpanded.not())
-                    } else {
-                        model
-                    }
+            val newValueTaking = uiState.medicationsTaking.medications.map { model ->
+                if (model.id == medicationId) {
+                    model.copy(isExpanded = model.isExpanded.not())
+                } else {
+                    model
                 }
-            MedicationUiState.Success(newValue)
+            }
+            val newValueMayHelp = uiState.medicationsThatMayHelp.medications.map { model ->
+                if (model.id == medicationId) {
+                    model.copy(isExpanded = model.isExpanded.not())
+                } else {
+                    model
+                }
+            }
+            MedicationUiState.Success(
+                medicationsTaking = Medications(
+                    medications = newValueTaking,
+                    expanded = uiState.medicationsTaking.expanded
+                ),
+                medicationsThatMayHelp = Medications(
+                    medications = newValueMayHelp,
+                    expanded = uiState.medicationsThatMayHelp.expanded
+                ),
+                colorKeyExpanded = uiState.colorKeyExpanded,
+            )
         } else {
             uiState
         }
@@ -65,17 +117,12 @@ class MedicationUiStateMapper @Inject constructor(
             listOf(context.getString(R.string.dosage_information_not_available))
         } else {
             schedules.map { schedule ->
-                val values = schedule
-                    .quantity
-                    .map { it.toString() }
-                    .joinToString("/") { it }
+                val values = schedule.quantity.map { it.toString() }.joinToString("/") { it }
                 val frequency = when (val value = schedule.frequency) {
                     1.0 -> ""
                     2.0 -> "twice "
                     else -> {
-                        val sanitized = value.toString()
-                            .removeSuffix(".0")
-                            .removeSuffix(",0")
+                        val sanitized = value.toString().removeSuffix(".0").removeSuffix(",0")
                         "${sanitized}x "
                     }
                 }
@@ -98,12 +145,10 @@ class MedicationUiStateMapper @Inject constructor(
             currentDose = DosageRowInfoData(
                 label = context.getString(R.string.dosage_information_dose_row_current_dose),
                 dosageValues = dosageValues(dosageInformation.currentSchedule, unit),
-            ),
-            targetDose = DosageRowInfoData(
+            ), targetDose = DosageRowInfoData(
                 label = context.getString(R.string.dosage_information_dose_row_target_dose),
                 dosageValues = dosageValues(dosageInformation.targetSchedule, unit),
-            ),
-            progress = progress.toFloat().coerceIn(0f, 1.0f)
+            ), progress = progress.toFloat().coerceIn(0f, 1.0f)
         )
     }
 
@@ -137,7 +182,7 @@ class MedicationUiStateMapper @Inject constructor(
 
             MedicationRecommendationType.NOT_STARTED,
             MedicationRecommendationType.NO_ACTION_REQUIRED,
-            -> MedicationColor.GREY
+            -> MedicationColor.BLUE
         }
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModel.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModel.kt
@@ -105,10 +105,10 @@ class MedicationViewModel @Inject internal constructor(
     interface Action {
         data class ToggleExpand(val medicationId: String) : Action
         data class InfoClicked(val videoPath: String) : Action
-        data class ToggleSectionExpand(val section: SECTION) : Action
+        data class ToggleSectionExpand(val section: Section) : Action
     }
 
-    enum class SECTION {
+    enum class Section {
         MEDICATIONS_TAKING,
         MEDICATIONS_THAT_MAY_HELP,
         COLOR_KEY,

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModel.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModel.kt
@@ -86,11 +86,31 @@ class MedicationViewModel @Inject internal constructor(
                     }
                 }
             }
+
+            is Action.ToggleSectionExpand -> {
+                _uiState.update {
+                    if (it is MedicationUiState.Success) {
+                        medicationUiStateMapper.toggleItemExpand(
+                            section = action.section,
+                            uiState = it
+                        )
+                    } else {
+                        it
+                    }
+                }
+            }
         }
     }
 
     interface Action {
         data class ToggleExpand(val medicationId: String) : Action
         data class InfoClicked(val videoPath: String) : Action
+        data class ToggleSectionExpand(val section: SECTION) : Action
+    }
+
+    enum class SECTION {
+        MEDICATIONS_TAKING,
+        MEDICATIONS_THAT_MAY_HELP,
+        COLOR_KEY,
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -97,4 +97,11 @@
     <string name="ble_device_error_subtitle">Something went wrong, please try again later.</string>
     <string name="your_devices_header_title">Your devices</string>
     <string name="last_seen_on">Last seen on %1$s</string>
+    <string name="medication_you_are_taking">Medication You are Taking</string>
+    <string name="medications_that_may_help">Medications That May Help</string>
+    <string name="color_key">Color key</string>
+    <string name="no_medications_to_show">No medications to show</string>
+    <string name="on_target_dose_that_best_helps_your_heart">On target dose that best helps your heart</string>
+    <string name="on_medication_but_may_benefit_from_a_higher_dose">On medication but may benefit from a higher dose</string>
+    <string name="not_on_this_medication_that_may_help_your_heart">Not on this medication that may help your heart</string>
 </resources>

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
@@ -135,17 +135,17 @@ class MedicationUiStateMapperTest {
 
         // when
         var result = medicationUiStateMapper.toggleItemExpand(
-            MedicationViewModel.SECTION.MEDICATIONS_TAKING,
+            MedicationViewModel.Section.MEDICATIONS_TAKING,
             uiState
         )
         result =
             medicationUiStateMapper.toggleItemExpand(
-                MedicationViewModel.SECTION.COLOR_KEY,
+                MedicationViewModel.Section.COLOR_KEY,
                 result as MedicationUiState.Success
             )
 
         result = medicationUiStateMapper.toggleItemExpand(
-            MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP,
+            MedicationViewModel.Section.MEDICATIONS_THAT_MAY_HELP,
             result as MedicationUiState.Success
         )
 

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
@@ -24,7 +24,7 @@ class MedicationUiStateMapperTest {
     }
 
     @Test
-    fun `given medication details when mapMedicationUiState then return sorted success state`() {
+    fun `given medication details when mapMedicationUiState then return filtered success state`() {
         // given
         val recommendations = getRecommendations()
 
@@ -33,9 +33,8 @@ class MedicationUiStateMapperTest {
 
         // then
         assertThat(result).isInstanceOf(MedicationUiState.Success::class.java)
-        assertThat((result as MedicationUiState.Success).uiModels).hasSize(2)
-        assertThat(result.uiModels[0].id).isEqualTo("1")
-        assertThat(result.uiModels[1].id).isEqualTo("2")
+        assertThat((result as MedicationUiState.Success).medicationsTaking.medications).hasSize(1)
+        assertThat(result.medicationsTaking.medications[0].id).isEqualTo("1")
     }
 
     @Test
@@ -57,7 +56,9 @@ class MedicationUiStateMapperTest {
         val medicationId = "id"
         val model = getMedicationCardUiModel(id = medicationId, isExpanded = initialIsExpandedState)
         val uiState = MedicationUiState.Success(
-            uiModels = listOf(model)
+            medicationsTaking = Medications(listOf(model), true),
+            medicationsThatMayHelp = Medications(listOf(model), true),
+            colorKeyExpanded = true
         )
 
         // when
@@ -65,8 +66,10 @@ class MedicationUiStateMapperTest {
 
         // then
         assertThat(result).isInstanceOf(MedicationUiState.Success::class.java)
-        assertThat((result as MedicationUiState.Success).uiModels).hasSize(1)
-        assertThat(result.uiModels.first().isExpanded).isEqualTo(initialIsExpandedState.not())
+        assertThat((result as MedicationUiState.Success).medicationsTaking.medications).hasSize(1)
+        assertThat(result.medicationsTaking.medications.first().isExpanded).isEqualTo(
+            initialIsExpandedState.not()
+        )
     }
 
     @Test
@@ -76,7 +79,9 @@ class MedicationUiStateMapperTest {
         val medicationId = "id"
         val model = getMedicationCardUiModel(id = medicationId, isExpanded = initialIsExpandedState)
         val uiState = MedicationUiState.Success(
-            uiModels = listOf(model)
+            medicationsTaking = Medications(listOf(model), true),
+            medicationsThatMayHelp = Medications(listOf(model), true),
+            colorKeyExpanded = true
         )
 
         // when
@@ -84,8 +89,10 @@ class MedicationUiStateMapperTest {
 
         // then
         assertThat(result).isInstanceOf(MedicationUiState.Success::class.java)
-        assertThat((result as MedicationUiState.Success).uiModels).hasSize(1)
-        assertThat(result.uiModels.first().isExpanded).isEqualTo(initialIsExpandedState)
+        assertThat((result as MedicationUiState.Success).medicationsTaking.medications).hasSize(1)
+        assertThat(result.medicationsTaking.medications.first().isExpanded).isEqualTo(
+            initialIsExpandedState
+        )
     }
 
     @Test
@@ -111,8 +118,8 @@ class MedicationUiStateMapperTest {
 
         // then
         assertThat(result).isInstanceOf(MedicationUiState.Success::class.java)
-        assertThat((result as MedicationUiState.Success).uiModels).hasSize(1)
-        assertThat(result.uiModels[0].dosageInformation).isNotNull()
+        assertThat((result as MedicationUiState.Success).medicationsTaking.medications).hasSize(1)
+        assertThat(result.medicationsTaking.medications[0].dosageInformation).isNotNull()
     }
 
     private fun getMedicationCardUiModel(
@@ -122,7 +129,7 @@ class MedicationUiStateMapperTest {
         description: String = "",
         isExpanded: Boolean = false,
         statusIconResId: Int? = null,
-        statusColor: MedicationColor = MedicationColor.GREY,
+        statusColor: MedicationColor = MedicationColor.BLUE,
         dosageInformation: DosageInformationUiModel? = null,
         videoPath: String = "",
     ) = MedicationCardUiModel(

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationUiStateMapperTest.kt
@@ -122,6 +122,47 @@ class MedicationUiStateMapperTest {
         assertThat(result.medicationsTaking.medications[0].dosageInformation).isNotNull()
     }
 
+    @Test
+    fun `given SuccessState when toggleItemExpand then return updated SuccessState`() {
+        // given
+        val initialIsExpandedState = false
+        val model = getMedicationCardUiModel()
+        val uiState = MedicationUiState.Success(
+            medicationsTaking = Medications(listOf(model), initialIsExpandedState),
+            medicationsThatMayHelp = Medications(listOf(model), initialIsExpandedState),
+            colorKeyExpanded = initialIsExpandedState
+        )
+
+        // when
+        var result = medicationUiStateMapper.toggleItemExpand(
+            MedicationViewModel.SECTION.MEDICATIONS_TAKING,
+            uiState
+        )
+        result =
+            medicationUiStateMapper.toggleItemExpand(
+                MedicationViewModel.SECTION.COLOR_KEY,
+                result as MedicationUiState.Success
+            )
+
+        result = medicationUiStateMapper.toggleItemExpand(
+            MedicationViewModel.SECTION.MEDICATIONS_THAT_MAY_HELP,
+            result as MedicationUiState.Success
+        )
+
+        // then
+        assertThat(result).isInstanceOf(MedicationUiState.Success::class.java)
+        assertThat((result as MedicationUiState.Success).medicationsTaking.medications).hasSize(1)
+        assertThat(result.medicationsTaking.expanded).isEqualTo(
+            initialIsExpandedState.not()
+        )
+        assertThat(result.medicationsThatMayHelp.expanded).isEqualTo(
+            initialIsExpandedState.not()
+        )
+        assertThat(result.colorKeyExpanded).isEqualTo(
+            initialIsExpandedState.not()
+        )
+    }
+
     private fun getMedicationCardUiModel(
         id: String = "",
         title: String = "",

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
@@ -45,7 +45,11 @@ class MedicationViewModelTest {
         )
         every {
             medicationUiStateMapper.mapMedicationUiState(recommendations)
-        } returns MedicationUiState.Success(uiModels)
+        } returns MedicationUiState.Success(
+            medicationsTaking = Medications(medications = uiModels, expanded = true),
+            medicationsThatMayHelp = Medications(medications = uiModels, expanded = true),
+            colorKeyExpanded = true
+        )
         viewModel = MedicationViewModel(
             medicationRepository,
             medicationUiStateMapper,
@@ -61,21 +65,32 @@ class MedicationViewModelTest {
         // given
         every {
             medicationUiStateMapper.mapMedicationUiState(recommendations)
-        } returns MedicationUiState.Success(uiModels)
+        } returns MedicationUiState.Success(
+            medicationsTaking = Medications(medications = uiModels, expanded = true),
+            medicationsThatMayHelp = Medications(medications = uiModels, expanded = true),
+            colorKeyExpanded = true,
+        )
 
         // when
         val uiState = viewModel.uiState.value
 
         // then
         assertThat(uiState).isInstanceOf(MedicationUiState.Success::class.java)
-        assertThat((uiState as MedicationUiState.Success).uiModels).isEqualTo(uiModels)
+        assertThat((uiState as MedicationUiState.Success).medicationsTaking.medications).isEqualTo(
+            uiModels
+        )
+        assertThat(uiState.medicationsThatMayHelp.medications).isEqualTo(uiModels)
     }
 
     @Test
     fun `given success state when expand action then uiState is updated`() = runTestUnconfined {
         // given
         val medicationId = "some-id"
-        val toggledResult = MedicationUiState.Success(uiModels = emptyList())
+        val toggledResult = MedicationUiState.Success(
+            medicationsTaking = Medications(medications = emptyList(), expanded = true),
+            medicationsThatMayHelp = Medications(medications = emptyList(), expanded = true),
+            colorKeyExpanded = true
+        )
         every {
             medicationUiStateMapper.expandMedication(
                 medicationId = medicationId,

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
@@ -72,7 +72,7 @@ class MedicationViewModelTest {
             )
             every {
                 medicationUiStateMapper.toggleItemExpand(
-                    section = MedicationViewModel.SECTION.MEDICATIONS_TAKING,
+                    section = MedicationViewModel.Section.MEDICATIONS_TAKING,
                     uiState = initialState
                 )
             } returns initialState.copy(
@@ -80,7 +80,7 @@ class MedicationViewModelTest {
             )
 
             // when
-            viewModel.onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_TAKING))
+            viewModel.onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.Section.MEDICATIONS_TAKING))
 
             // then
             val result = viewModel.uiState.value

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/medication/ui/MedicationViewModelTest.kt
@@ -61,6 +61,37 @@ class MedicationViewModelTest {
     }
 
     @Test
+    fun `given success state when ToggleSectionExpand action then uiState is updated`() =
+        runTestUnconfined {
+            // given
+            val givenExpanded = true
+            val initialState = MedicationUiState.Success(
+                medicationsTaking = Medications(medications = uiModels, expanded = givenExpanded),
+                medicationsThatMayHelp = Medications(medications = uiModels, expanded = true),
+                colorKeyExpanded = true
+            )
+            every {
+                medicationUiStateMapper.toggleItemExpand(
+                    section = MedicationViewModel.SECTION.MEDICATIONS_TAKING,
+                    uiState = initialState
+                )
+            } returns initialState.copy(
+                medicationsTaking = initialState.medicationsTaking.copy(expanded = false)
+            )
+
+            // when
+            viewModel.onAction(MedicationViewModel.Action.ToggleSectionExpand(MedicationViewModel.SECTION.MEDICATIONS_TAKING))
+
+            // then
+            val result = viewModel.uiState.value
+            assertThat(result).isEqualTo(
+                initialState.copy(
+                    medicationsTaking = initialState.medicationsTaking.copy(expanded = givenExpanded.not())
+                )
+            )
+        }
+
+    @Test
     fun `given medication details when initialized then uiState is success`() = runTestUnconfined {
         // given
         every {


### PR DESCRIPTION
# *Adding Sections to Meds Page + Change Medication Status Colors + add a key*

## :recycle: Current situation & Problem

1. Patients wanted a different color scheme for their medication treatment progress
2. Patients wanted a more clear picture of what medications they are currently taking versus the ones they are not.


## :gear: Release Notes 

- Changed the colors of the different medications based on patient treatment status and added a key for those colors either to the top or bottom of the medications page.

- Separated the page into two sections: medications the patient is taking vs the medications they are not taking

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
