### PR TITLE
Sync of paired devices once permissions are given

### DIFF
--- a/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEPairedDevicesStorage.kt
+++ b/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEPairedDevicesStorage.kt
@@ -12,6 +12,7 @@ import edu.stanford.spezi.modules.storage.key.getSerializableList
 import edu.stanford.spezi.modules.storage.key.putSerializable
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -29,11 +30,11 @@ internal class BLEPairedDevicesStorage @Inject constructor(
     private val logger by speziLogger()
 
     private val _pairedDevices = MutableStateFlow(emptyList<BLEDevice>())
-    val pairedDevices = _pairedDevices.asStateFlow()
 
-    init {
+    fun observePairedDevices(): StateFlow<List<BLEDevice>> {
         refreshState()
         observeUnpairingEvents()
+        return _pairedDevices.asStateFlow()
     }
 
     fun updateDeviceConnection(device: BluetoothDevice, connected: Boolean) {

--- a/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
+++ b/core/bluetooth/src/main/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceImpl.kt
@@ -143,7 +143,7 @@ internal class BLEServiceImpl @Inject constructor(
 
     private fun startPairedDevicesStorageCollection() {
         scope.launch {
-            pairedDevicesStorage.pairedDevices.collect { devices ->
+            pairedDevicesStorage.observePairedDevices().collect { devices ->
                 _state.update { BLEServiceState.Scanning(devices) }
             }
         }

--- a/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
+++ b/core/bluetooth/src/test/kotlin/edu/stanford/spezi/core/bluetooth/domain/BLEServiceTest.kt
@@ -74,7 +74,7 @@ class BLEServiceTest {
             every { startScanning(services = services) } just Runs
             every { stopScanning() } just Runs
         }
-        every { pairedDevicesStorage.pairedDevices } returns pairedDevicesState
+        every { pairedDevicesStorage.observePairedDevices() } returns pairedDevicesState
         every { pairedDevicesStorage.isPaired(any()) } returns true
         every { bleDevicePairingNotifier.events } returns notifierEvents
     }
@@ -149,7 +149,7 @@ class BLEServiceTest {
         // then
         verify { bleDevicePairingNotifier.events }
         verify { bleDevicePairingNotifier.start() }
-        verify { pairedDevicesStorage.pairedDevices }
+        verify { pairedDevicesStorage.observePairedDevices() }
         verify { deviceScanner.events }
         verify { deviceScanner.startScanning(services = services) }
     }


### PR DESCRIPTION
# Sync of paired devices once permissions are given

## :recycle: Current situation & Problem
@Basler182 noticed a crash after deleting and reinstalling the app, where Bluetooth permissions are lost. The issue was related to the paired devices storage component that was attempting to sync on init. Adapting syncing of devices after we have guaranteed in BLEService that the permissions are given. Crash stacktrace

```

java.lang.SecurityException: Need android.permission.BLUETOOTH_CONNECT permission for android.content.AttributionSource@b445b3e6: AdapterService getBondedDevices
at android.os.Parcel.createExceptionOrNull(Parcel.java:3242)
at android.os.Parcel.createException(Parcel.java:3226)
at android.os.Parcel.readException(Parcel.java:3209)
at android.os.Parcel.readException(Parcel.java:3151)
at android.bluetooth.IBluetooth$Stub$Proxy.getBondedDevices(IBluetooth.java:2622)
at android.bluetooth.BluetoothAdapter.getBondedDevices(BluetoothAdapter.java:2818)
at edu.stanford.spezi.core.bluetooth.domain.BLEPairedDevicesStorage.refreshState(BLEPairedDevicesStorage.kt:54)
at edu.stanford.spezi.core.bluetooth.domain.BLEPairedDevicesStorage.<init>(BLEPairedDevicesStorage.kt:35)
```


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
