### PR TITLE
Error handling when generating Health summary

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -35,4 +35,12 @@
         </provider>
     </application>
 
+    <queries>
+        <!-- Intent query to open PDF files -->
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:mimeType="application/pdf" />
+        </intent>
+    </queries>
+
 </manifest>

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/HealthSummaryService.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/HealthSummaryService.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.os.Environment
 import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
+import edu.stanford.bdh.engagehf.R
 import edu.stanford.spezi.core.coroutines.di.Dispatching
 import edu.stanford.spezi.core.logging.speziLogger
 import edu.stanford.spezi.core.utils.MessageNotifier
@@ -31,14 +32,18 @@ class HealthSummaryService @Inject constructor(
                     "${context.packageName}.provider",
                     savePdfToFile
                 )
-                Intent(Intent.ACTION_VIEW).run {
+                val pdfIntent = Intent(Intent.ACTION_VIEW).apply {
                     addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     setDataAndType(pdfUri, MIME_TYPE_PDF)
-                    context.startActivity(this)
+                }
+                if (pdfIntent.resolveActivity(context.packageManager) == null) {
+                    messageNotifier.notify(messageId = R.string.no_pdf_reader_app_installed_error_message)
+                } else {
+                    context.startActivity(pdfIntent)
                 }
             }.onFailure {
-                messageNotifier.notify("Failed to generate Health Summary")
+                messageNotifier.notify(messageId = R.string.health_summary_generate_error_message)
             }
     }
 

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/HealthSummaryService.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/HealthSummaryService.kt
@@ -2,7 +2,6 @@ package edu.stanford.bdh.engagehf.messages
 
 import android.content.Context
 import android.content.Intent
-import android.os.Environment
 import androidx.core.content.FileProvider
 import dagger.hilt.android.qualifiers.ApplicationContext
 import edu.stanford.bdh.engagehf.R
@@ -49,8 +48,8 @@ class HealthSummaryService @Inject constructor(
 
     private fun savePdfToFile(pdfBytes: ByteArray): File {
         logger.i { "PDF size: ${pdfBytes.size}" }
-        val storageDir =
-            Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)
+
+        val storageDir = context.getExternalFilesDir(null) ?: context.filesDir
         if (!storageDir.exists()) {
             storageDir.mkdirs()
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,4 +122,6 @@
     <string name="dizziness_score_title">Dizziness Score</string>
     <string name="dizziness_score_description">Your dizziness is important to keep track of because dizziness can be a side effect of your heart or your heart medicines.</string>
     <string name="error_while_handling_message_action">Error while handling message action.</string>
+    <string name="no_pdf_reader_app_installed_error_message">Health Summary generated successfully, but no PDF reader is installed on the device"</string>
+    <string name="health_summary_generate_error_message">Failed to generate Health Summary</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -122,6 +122,6 @@
     <string name="dizziness_score_title">Dizziness Score</string>
     <string name="dizziness_score_description">Your dizziness is important to keep track of because dizziness can be a side effect of your heart or your heart medicines.</string>
     <string name="error_while_handling_message_action">Error while handling message action.</string>
-    <string name="no_pdf_reader_app_installed_error_message">Health Summary generated successfully, but no PDF reader is installed on the device"</string>
+    <string name="no_pdf_reader_app_installed_error_message">Health Summary generated successfully, but no PDF reader is installed on the device</string>
     <string name="health_summary_generate_error_message">Failed to generate Health Summary</string>
 </resources>

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
 
 android {
     namespace = "edu.stanford.spezi.utils"
+
+    defaultConfig {
+        testInstrumentationRunner = "edu.stanford.spezi.core.utils.HiltApplicationTestRunner"
+    }
 }
 
 dependencies {
@@ -16,4 +20,5 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     testImplementation(libs.bundles.unit.testing)
+    androidTestImplementation(libs.bundles.unit.testing)
 }

--- a/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/HiltApplicationTestRunner.kt
+++ b/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/HiltApplicationTestRunner.kt
@@ -1,0 +1,13 @@
+package edu.stanford.spezi.core.utils
+
+import android.app.Application
+import android.content.Context
+import androidx.test.runner.AndroidJUnitRunner
+import dagger.hilt.android.testing.HiltTestApplication
+
+@Suppress("Unused")
+class HiltApplicationTestRunner : AndroidJUnitRunner() {
+    override fun newApplication(cl: ClassLoader?, className: String?, context: Context?): Application {
+        return super.newApplication(cl, HiltTestApplication::class.java.name, context)
+    }
+}

--- a/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/MessageNotifierTest.kt
+++ b/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/MessageNotifierTest.kt
@@ -32,7 +32,7 @@ class MessageNotifierTest {
     }
 
     @Test
-    fun `it should not fail when toasting in a different thread than main`() = runTest(StandardTestDispatcher()) {
+    fun `it should not fail when notifying on a background thread`() = runTest(StandardTestDispatcher()) {
         messageNotifier.notify("Some message")
     }
 }

--- a/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/MessageNotifierTest.kt
+++ b/core/utils/src/androidTest/kotlin/edu/stanford/spezi/core/utils/MessageNotifierTest.kt
@@ -1,0 +1,38 @@
+package edu.stanford.spezi.core.utils
+
+import androidx.test.platform.app.InstrumentationRegistry
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import javax.inject.Inject
+
+@HiltAndroidTest
+class MessageNotifierTest {
+
+    @get:Rule(order = 1)
+    val hiltRule = HiltAndroidRule(this)
+
+    @Inject
+    lateinit var messageNotifier: MessageNotifier
+
+    @Before
+    fun init() {
+        hiltRule.inject()
+    }
+
+    @Test
+    fun `it should not fail when toasting in main thread`() {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            messageNotifier.notify("Some message")
+        }
+    }
+
+    @Test
+    fun `it should not fail when toasting in a different thread than main`() = runTest(StandardTestDispatcher()) {
+        messageNotifier.notify("Some message")
+    }
+}

--- a/core/utils/src/main/kotlin/edu/stanford/spezi/core/utils/MessageNotifier.kt
+++ b/core/utils/src/main/kotlin/edu/stanford/spezi/core/utils/MessageNotifier.kt
@@ -1,6 +1,8 @@
 package edu.stanford.spezi.core.utils
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.widget.Toast
 import androidx.annotation.StringRes
 import dagger.hilt.android.qualifiers.ApplicationContext
@@ -9,9 +11,15 @@ import javax.inject.Inject
 class MessageNotifier @Inject constructor(
     @ApplicationContext private val context: Context,
 ) {
+    private val mainHandler by lazy { Handler(Looper.getMainLooper()) }
 
     fun notify(message: String, duration: Duration = Duration.SHORT) {
-        Toast.makeText(context, message, duration.value).show()
+        val toast = { Toast.makeText(context, message, duration.value).show() }
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            toast()
+        } else {
+            mainHandler.post { toast() }
+        }
     }
 
     fun notify(@StringRes messageId: Int, duration: Duration = Duration.SHORT) {


### PR DESCRIPTION
# *Health summary PDF generation*

## :recycle: Current situation & Problem
- Even though the summary pdf was generated successfully, the service was throwing because there was no PDF viewer app installed in the device
- We were able to catch the error and were attempting to show a toast. However, since the code is being executed in a background thread, the app was crashing because toast must be executed in the main thread.

Addressed the issue by:
- Ensuring that toast messages are executed always in the main thread
- Explicitly check whether after PDF generation whether there is an appropriate pdf reader app installed in the device. If not we display a toast message that summary is generated successfully but no pdf reader installed in the device. In case of success, the user will have the option to select the the pdf reader app via a default android bottom sheet


## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
