### PR TITLE
Fix message dismissing and extract message handling from home view model

### DIFF
--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/MainActivity.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/MainActivity.kt
@@ -22,8 +22,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import dagger.hilt.android.AndroidEntryPoint
-import edu.stanford.bdh.engagehf.bluetooth.HomeViewModel
-import edu.stanford.bdh.engagehf.bluetooth.data.models.Action
 import edu.stanford.bdh.engagehf.contact.ui.ContactScreen
 import edu.stanford.bdh.engagehf.navigation.AppNavigationEvent
 import edu.stanford.bdh.engagehf.navigation.RegisterParams
@@ -59,15 +57,13 @@ class MainActivity : FragmentActivity() {
 
     private val viewModel by viewModels<MainActivityViewModel>()
 
-    private val homeViewModel by viewModels<HomeViewModel>()
-
     @Inject
     @Dispatching.Main
     lateinit var mainDispatcher: CoroutineDispatcher
 
     override fun onNewIntent(intent: Intent) {
         super.onNewIntent(intent)
-        homeViewModel.onAction(Action.NewIntent(intent))
+        viewModel.onAction(action = MainActivityAction.NewIntent(intent))
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapper.kt
@@ -13,7 +13,6 @@ import edu.stanford.bdh.engagehf.bluetooth.data.models.MeasurementDialogUiState
 import edu.stanford.bdh.engagehf.bluetooth.data.models.VitalDisplayData
 import edu.stanford.bdh.engagehf.bluetooth.service.EngageBLEServiceState
 import edu.stanford.bdh.engagehf.bluetooth.service.Measurement
-import edu.stanford.bdh.engagehf.messages.MessagesAction
 import edu.stanford.spezi.core.design.component.StringResource
 import edu.stanford.spezi.core.utils.LocaleProvider
 import java.time.Instant
@@ -24,7 +23,6 @@ import javax.inject.Inject
 
 class BluetoothUiStateMapper @Inject constructor(
     private val localeProvider: LocaleProvider,
-    private val messageActionMapper: MessageActionMapper,
 ) {
 
     private val dateFormatter by lazy {
@@ -185,10 +183,6 @@ class BluetoothUiStateMapper @Inject constructor(
                 )
             }
         )
-    }
-
-    fun mapMessagesAction(action: String?): Result<MessagesAction?> {
-        return messageActionMapper.map(action)
     }
 
     private fun <T : Record> mapRecordResult(

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/MessageActionMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/MessageActionMapper.kt
@@ -11,10 +11,10 @@ class MessageActionMapper @Inject constructor() {
         private val questionnaireRegex = Regex("/?questionnaires/(.+)")
     }
 
-    fun map(action: String?): Result<MessagesAction?> {
+    fun map(action: String?): Result<MessagesAction> {
         return runCatching {
             when {
-                action.isNullOrBlank() -> null
+                action.isNullOrBlank() -> error("Invalid action type")
                 videoSectionRegex.matches(action) -> {
                     mapVideoSectionAction(action).getOrThrow()
                 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/models/Action.kt
@@ -1,6 +1,5 @@
 package edu.stanford.bdh.engagehf.bluetooth.data.models
 
-import android.content.Intent
 import edu.stanford.bdh.engagehf.bluetooth.service.Measurement
 import edu.stanford.bdh.engagehf.messages.Message
 
@@ -12,7 +11,6 @@ sealed interface Action {
     data class PermissionResult(val permission: String) : Action
     data object Resumed : Action
     data object BLEDevicePairing : Action
-    data class NewIntent(val intent: Intent) : Action
     data object VitalsCardClicked : Action
 
     sealed interface Settings : Action {

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/FirestoreMessageMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/FirestoreMessageMapper.kt
@@ -7,20 +7,19 @@ import java.time.ZoneId
 import java.time.ZonedDateTime
 import javax.inject.Inject
 
-internal class FirestoreMessageMapper @Inject constructor(
+class FirestoreMessageMapper @Inject constructor(
     private val localizedMapReader: LocalizedMapReader,
 ) {
 
-    @Suppress("ReturnCount")
     fun map(document: DocumentSnapshot): Message? {
         val jsonMap = document.data ?: return null
-        val dueDate = jsonMap["dueDate"] as? Timestamp?
+        val dueDate = jsonMap["dueDate"] as? Timestamp
         val completionDate = jsonMap["completionDate"] as? Timestamp
         val typeString = jsonMap["type"] as? String?
         val title = localizedMapReader.get(key = "title", jsonMap = jsonMap) ?: return null
         val description = localizedMapReader.get(key = "description", jsonMap = jsonMap)
         val action = jsonMap["action"] as? String?
-        val isDismissible = jsonMap["isDismissible"] as? Boolean ?: return null
+        val isDismissible = (jsonMap["isDismissible"] as? Boolean) == true
         val type = MessageType.fromString(typeString)
 
         return Message(

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepository.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepository.kt
@@ -2,28 +2,30 @@ package edu.stanford.bdh.engagehf.messages
 
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
+import com.google.firebase.functions.FirebaseFunctions
 import edu.stanford.spezi.core.coroutines.di.Dispatching
 import edu.stanford.spezi.core.logging.speziLogger
 import edu.stanford.spezi.module.account.manager.UserSessionManager
-import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.withContext
-import java.time.ZonedDateTime
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
-internal class MessageRepository @Inject constructor(
+class MessageRepository @Inject constructor(
     private val firestore: FirebaseFirestore,
+    private val firebaseFunctions: FirebaseFunctions,
     private val userSessionManager: UserSessionManager,
     private val firestoreMessageMapper: FirestoreMessageMapper,
-    @Dispatching.IO private val ioDispatcher: CoroutineDispatcher,
+    @Dispatching.IO private val ioScope: CoroutineScope,
 ) {
     private val logger by speziLogger()
 
-    suspend fun observeUserMessages(): Flow<List<Message>> = callbackFlow {
+    fun observeUserMessages(): Flow<List<Message>> = callbackFlow {
         var listenerRegistration: ListenerRegistration? = null
-        withContext(ioDispatcher) {
+        ioScope.launch {
             runCatching {
                 val uid = userSessionManager.getUserUid()
                     ?: throw IllegalStateException("User not authenticated")
@@ -38,7 +40,10 @@ internal class MessageRepository @Inject constructor(
                         }
                         value?.documents?.mapNotNull { document ->
                             firestoreMessageMapper.map(document)
-                        }?.let { trySend(it) }
+                        }?.let {
+                            logger.i { "Sending messages list update of size: ${it.size}" }
+                            trySend(it)
+                        }
                     }
             }.onFailure {
                 logger.e(it) { "Error while listening for user messages" }
@@ -50,19 +55,23 @@ internal class MessageRepository @Inject constructor(
         }
     }
 
-    suspend fun completeMessage(messageId: String) {
-        withContext(ioDispatcher) {
+    fun completeMessage(messageId: String) {
+        ioScope.launch {
             runCatching {
                 val uid = userSessionManager.getUserUid()
                     ?: throw IllegalStateException("User not authenticated")
-                firestore.collection("users")
-                    .document(uid)
-                    .collection("messages")
-                    .document(messageId)
-                    .update("completionDate", ZonedDateTime.now())
+                val params = mapOf(
+                    "userId" to uid,
+                    "messageId" to messageId,
+                )
+                firebaseFunctions.getHttpsCallable("dismissMessage")
+                    .call(params)
+                    .await()
+
+                logger.i { "Message completion for $messageId finished successfully" }
+            }.onFailure {
+                logger.e(it) { "Error while completing message" }
             }
-        }.onFailure {
-            logger.e(it) { "Error while completing message" }
         }
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepository.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepository.kt
@@ -70,7 +70,7 @@ class MessageRepository @Inject constructor(
 
                 logger.i { "Message completion for $messageId finished successfully" }
             }.onFailure {
-                logger.e(it) { "Error while completing message" }
+                logger.e(it) { "Error while completing message with id $messageId" }
             }
         }
     }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessagesHandler.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessagesHandler.kt
@@ -1,0 +1,72 @@
+package edu.stanford.bdh.engagehf.messages
+
+import edu.stanford.bdh.engagehf.R
+import edu.stanford.bdh.engagehf.bluetooth.component.AppScreenEvents
+import edu.stanford.bdh.engagehf.bluetooth.data.mapper.MessageActionMapper
+import edu.stanford.bdh.engagehf.education.EngageEducationRepository
+import edu.stanford.bdh.engagehf.navigation.AppNavigationEvent
+import edu.stanford.bdh.engagehf.navigation.screens.BottomBarItem
+import edu.stanford.spezi.core.logging.speziLogger
+import edu.stanford.spezi.core.navigation.Navigator
+import edu.stanford.spezi.core.utils.MessageNotifier
+import edu.stanford.spezi.modules.education.EducationNavigationEvent
+import javax.inject.Inject
+
+@Suppress("LongParameterList")
+class MessagesHandler @Inject constructor(
+    private val messagesActionMapper: MessageActionMapper,
+    private val appScreenEvents: AppScreenEvents,
+    private val healthSummaryService: HealthSummaryService,
+    private val engageEducationRepository: EngageEducationRepository,
+    private val navigator: Navigator,
+    private val messageRepository: MessageRepository,
+    private val messageNotifier: MessageNotifier,
+) {
+    private val logger by speziLogger()
+
+    fun observeUserMessages() = messageRepository.observeUserMessages()
+
+    suspend fun handle(message: Message) {
+        val actionResult = messagesActionMapper.map(action = message.action)
+        var failure = actionResult.exceptionOrNull()
+        when (val messagesAction = actionResult.getOrNull()) {
+            is MessagesAction.HealthSummaryAction -> {
+                failure = healthSummaryService.generateHealthSummaryPdf().exceptionOrNull()
+            }
+
+            is MessagesAction.VideoSectionAction -> {
+                val sectionVideo = messagesAction.videoSectionVideo
+                failure = engageEducationRepository.getVideoBySectionAndVideoId(
+                    sectionId = sectionVideo.videoSectionId,
+                    videoId = sectionVideo.videoId,
+                ).onSuccess { video ->
+                    navigator.navigateTo(EducationNavigationEvent.VideoSectionClicked(video))
+                }.exceptionOrNull()
+            }
+
+            is MessagesAction.MeasurementsAction -> {
+                appScreenEvents.emit(AppScreenEvents.Event.DoNewMeasurement)
+            }
+
+            is MessagesAction.MedicationsAction -> {
+                appScreenEvents.emit(AppScreenEvents.Event.NavigateToTab(BottomBarItem.MEDICATION))
+            }
+
+            is MessagesAction.QuestionnaireAction -> {
+                navigator.navigateTo(
+                    AppNavigationEvent.QuestionnaireScreen(messagesAction.questionnaireId)
+                )
+            }
+            else -> Unit
+        }
+        val messageId = message.id
+        if (failure == null && message.isDismissible) {
+            messageRepository.completeMessage(messageId = messageId)
+        } else if (failure != null) {
+            logger.e(failure) { "Error while handling message: $messageId" }
+            messageNotifier.notify(messageId = R.string.error_while_handling_message_action)
+        } else {
+            logger.i { "Message $messageId handled successfully" }
+        }
+    }
+}

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/BluetoothUiStateMapperTest.kt
@@ -25,11 +25,8 @@ class BluetoothUiStateMapperTest {
         every { getDefaultLocale() } returns Locale.US
     }
 
-    private val messageActionMapper = mockk<MessageActionMapper>()
-
     private val mapper = BluetoothUiStateMapper(
         localeProvider = localeProvider,
-        messageActionMapper = messageActionMapper
     )
     private val bloodPressure: Measurement.BloodPressure = mockk {
         every { systolic } returns SYSTOLIC.toFloat()

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/MessageActionMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/bluetooth/data/mapper/MessageActionMapperTest.kt
@@ -9,6 +9,19 @@ class MessageActionMapperTest {
     private val mapper = MessageActionMapper()
 
     @Test
+    fun `it should return error result for null action`() {
+        // given
+        val action: String? = null
+
+        // when
+        val exception = mapper.map(action).exceptionOrNull()
+
+        // then
+        assertThat(exception).isInstanceOf(IllegalStateException::class.java)
+        assertThat(exception?.message).isEqualTo("Invalid action type")
+    }
+
+    @Test
     fun `it should map video section action correctly`() {
         // given
         val sectionId = "some-section-id-12-34."

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepositoryTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/messages/MessageRepositoryTest.kt
@@ -1,26 +1,28 @@
 package edu.stanford.bdh.engagehf.messages
 
 import com.google.common.truth.Truth.assertThat
-import com.google.firebase.firestore.DocumentReference
 import com.google.firebase.firestore.DocumentSnapshot
 import com.google.firebase.firestore.EventListener
 import com.google.firebase.firestore.FirebaseFirestore
 import com.google.firebase.firestore.ListenerRegistration
 import com.google.firebase.firestore.QuerySnapshot
+import com.google.firebase.functions.FirebaseFunctions
+import com.google.firebase.functions.HttpsCallableReference
+import edu.stanford.spezi.core.testing.SpeziTestScope
+import edu.stanford.spezi.core.testing.mockTask
 import edu.stanford.spezi.core.testing.runTestUnconfined
+import edu.stanford.spezi.core.testing.verifyNever
 import edu.stanford.spezi.module.account.manager.UserSessionManager
-import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import org.junit.Test
 
 class MessageRepositoryTest {
     private val uid = "some-uid"
     private val firestore: FirebaseFirestore = mockk()
+    private val firebaseFunctions: FirebaseFunctions = mockk()
     private val userSessionManager: UserSessionManager = mockk {
         every { getUserUid() } returns uid
     }
@@ -28,9 +30,10 @@ class MessageRepositoryTest {
 
     private val repository = MessageRepository(
         firestore = firestore,
+        firebaseFunctions = firebaseFunctions,
         userSessionManager = userSessionManager,
         firestoreMessageMapper = firestoreMessageMapper,
-        ioDispatcher = UnconfinedTestDispatcher()
+        ioScope = SpeziTestScope()
     )
 
     @Test
@@ -71,22 +74,35 @@ class MessageRepositoryTest {
     }
 
     @Test
-    fun `completeMessage updates completionDate successfully`() = runTestUnconfined {
+    fun `dismissMessage is invoked correctly`() {
         // given
         val messageId = "some-message-id"
-        val documentReference: DocumentReference = mockk()
-        coEvery { documentReference.update("completionDate", any()) } returns mockk()
+        val httpsCallableReference: HttpsCallableReference = mockk()
+        val paramsSlot = slot<Map<String, String>>()
         every {
-            firestore.collection("users")
-                .document(uid)
-                .collection("messages")
-                .document(messageId)
-        } returns documentReference
+            firebaseFunctions.getHttpsCallable("dismissMessage")
+        } returns httpsCallableReference
+        every { httpsCallableReference.call(capture(paramsSlot)) } returns mockTask(mockk())
 
         // when
         repository.completeMessage(messageId)
 
         // then
-        coVerify { documentReference.update("completionDate", any()) }
+        val params = paramsSlot.captured
+        assertThat(params["userId"]).isEqualTo(uid)
+        assertThat(params["messageId"]).isEqualTo(messageId)
+    }
+
+    @Test
+    fun `it should not dismissMessage if user is not authenticated`() {
+        // given
+        val messageId = "some-message-id"
+        every { userSessionManager.getUserUid() } returns null
+
+        // when
+        repository.completeMessage(messageId)
+
+        // then
+        verifyNever { firebaseFunctions.getHttpsCallable("dismissMessage") }
     }
 }

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/messages/MessagesHandlerTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/messages/MessagesHandlerTest.kt
@@ -1,0 +1,219 @@
+package edu.stanford.bdh.engagehf.messages
+
+import com.google.common.truth.Truth.assertThat
+import edu.stanford.bdh.engagehf.R
+import edu.stanford.bdh.engagehf.bluetooth.component.AppScreenEvents
+import edu.stanford.bdh.engagehf.bluetooth.data.mapper.MessageActionMapper
+import edu.stanford.bdh.engagehf.education.EngageEducationRepository
+import edu.stanford.bdh.engagehf.navigation.AppNavigationEvent
+import edu.stanford.bdh.engagehf.navigation.screens.BottomBarItem
+import edu.stanford.spezi.core.navigation.Navigator
+import edu.stanford.spezi.core.testing.coVerifyNever
+import edu.stanford.spezi.core.testing.runTestUnconfined
+import edu.stanford.spezi.core.testing.verifyNever
+import edu.stanford.spezi.core.utils.MessageNotifier
+import edu.stanford.spezi.modules.education.EducationNavigationEvent
+import edu.stanford.spezi.modules.education.videos.Video
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
+import org.junit.Test
+
+class MessagesHandlerTest {
+    private val actionMapper: MessageActionMapper = mockk()
+    private val messageRepository = mockk<MessageRepository>(relaxed = true)
+    private val engageEducationRepository = mockk<EngageEducationRepository>(relaxed = true)
+    private val healthSummaryService = mockk<HealthSummaryService>(relaxed = true)
+    private val messageNotifier = mockk<MessageNotifier>(relaxed = true)
+    private val appScreenEvents = mockk<AppScreenEvents>(relaxed = true)
+    private val navigator = mockk<Navigator>(relaxed = true)
+    private val messageAction = "some-action"
+    private val messageId = "some-id"
+    private val videoSectionId = "some-video-section-id"
+    private val videoId = "some-video-id"
+    private val sectionVideo = VideoSectionVideo(
+        videoSectionId = videoSectionId,
+        videoId = videoId,
+    )
+    private val message: Message = mockk {
+        every { action } returns messageAction
+        every { id } returns messageId
+        every { isExpanded } returns false
+        every { isDismissible } returns true
+    }
+
+    private val messagesHandler by lazy {
+        MessagesHandler(
+            messagesActionMapper = actionMapper,
+            appScreenEvents = appScreenEvents,
+            healthSummaryService = healthSummaryService,
+            engageEducationRepository = engageEducationRepository,
+            navigator = navigator,
+            messageRepository = messageRepository,
+            messageNotifier = messageNotifier,
+        )
+    }
+
+    @Test
+    fun `it should not handle message if action mapping fails`() = runTestUnconfined {
+        // given
+        every { actionMapper.map(messageAction) } returns Result.failure(Throwable())
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        assertError()
+    }
+
+    @Test
+    fun `it should return message updates of the repository`() = runTestUnconfined {
+        // given
+        val updates: Flow<List<Message>> = emptyFlow()
+        every { messageRepository.observeUserMessages() } returns updates
+
+        // when
+        val result = messagesHandler.observeUserMessages()
+
+        // then
+        assertThat(result).isEqualTo(updates)
+    }
+
+    @Test
+    fun `it should handle HealthSummaryAction correctly on non error result`() = runTestUnconfined {
+        // given
+        setup(action = MessagesAction.HealthSummaryAction)
+        coEvery { healthSummaryService.generateHealthSummaryPdf() } returns Result.success(Unit)
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        assertSuccess()
+    }
+
+    @Test
+    fun `it should not dismiss health summary message on error result`() = runTestUnconfined {
+        // given
+        setup(action = MessagesAction.HealthSummaryAction)
+        coEvery {
+            healthSummaryService.generateHealthSummaryPdf()
+        } returns Result.failure(Throwable())
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        assertError()
+    }
+
+    @Test
+    fun `it should not dismiss video section message on error result`() = runTestUnconfined {
+        // given
+        setup(action = MessagesAction.VideoSectionAction(sectionVideo))
+        coEvery {
+            engageEducationRepository.getVideoBySectionAndVideoId(
+                sectionId = videoSectionId,
+                videoId = videoId,
+            )
+        } returns Result.failure(Throwable())
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        assertError()
+    }
+
+    @Test
+    fun `it should handle video section action correctly`() = runTestUnconfined {
+        val video: Video = mockk()
+        val videoSectionAction = MessagesAction.VideoSectionAction(videoSectionVideo = sectionVideo)
+        setup(action = videoSectionAction)
+        coEvery {
+            engageEducationRepository.getVideoBySectionAndVideoId(videoSectionId, videoId)
+        } returns Result.success(video)
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        verify { navigator.navigateTo(EducationNavigationEvent.VideoSectionClicked(video)) }
+        assertSuccess()
+    }
+
+    @Test
+    fun `it should handle MeasurementsAction correctly`() = runTestUnconfined {
+        // given
+        setup(action = MessagesAction.MeasurementsAction)
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        verify { appScreenEvents.emit(AppScreenEvents.Event.DoNewMeasurement) }
+        assertSuccess()
+    }
+
+    @Test
+    fun `it should navigate to questionnaire screen on QuestionnaireAction`() = runTestUnconfined {
+        // given
+        val questionnaireId = "1"
+        setup(action = MessagesAction.QuestionnaireAction(questionnaireId))
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        verify { navigator.navigateTo(AppNavigationEvent.QuestionnaireScreen(questionnaireId)) }
+        assertSuccess()
+    }
+
+    @Test
+    fun `it should handle medication change action correctly`() = runTestUnconfined {
+        // given
+        setup(action = MessagesAction.MedicationsAction)
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        verify { appScreenEvents.emit(AppScreenEvents.Event.NavigateToTab(BottomBarItem.MEDICATION)) }
+        assertSuccess()
+    }
+
+    @Test
+    fun `it should not dismiss non-dismissable messages on success`() = runTestUnconfined {
+        // given
+        every { message.isDismissible } returns false
+        setup(action = MessagesAction.MedicationsAction)
+
+        // when
+        messagesHandler.handle(message = message)
+
+        // then
+        verify { appScreenEvents.emit(AppScreenEvents.Event.NavigateToTab(BottomBarItem.MEDICATION)) }
+        coVerifyNever { messageRepository.completeMessage(messageId = messageId) }
+        verifyNever { messageNotifier.notify(R.string.error_while_handling_message_action) }
+    }
+
+    private fun assertError() {
+        verify(exactly = 1) {
+            messageNotifier.notify(R.string.error_while_handling_message_action)
+        }
+        coVerifyNever { messageRepository.completeMessage(messageId = messageId) }
+    }
+
+    private fun assertSuccess() {
+        verifyNever { messageNotifier.notify(R.string.error_while_handling_message_action) }
+        coVerify(exactly = 1) { messageRepository.completeMessage(messageId = messageId) }
+    }
+
+    private fun setup(action: MessagesAction) {
+        every { actionMapper.map(messageAction) } returns Result.success(action)
+    }
+}


### PR DESCRIPTION
# *Message completion*

## :recycle: Current situation & Problem
- Fixes #101 by extracting message handling logic out of home view model and reuse in main activity during push notifications flow
- Fixes #153 by using `dismissMessage` firebase function instead of updating `completionDate` field. Messages are dismissed correctly now, and we receive a new update (within a couple of seconds) upon dismissal via the snapshot listener
- Adapt and extend unit tests

## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
