### PR TITLE
Task/issue 165

### DIFF
--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/time/TimePickerStateMapper.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/time/TimePickerStateMapper.kt
@@ -22,7 +22,7 @@ class TimePickerStateMapper @Inject constructor(
             selectedTime = localTime,
             initialHour = localTime.hour,
             initialMinute = localTime.minute,
-            selectedDateFormatted = format(now),
+            selectedDateFormatted = dateFormatter.formatDefaultZoneId(now, DATE_FORMAT),
             selectedTimeFormatted = format(localTime)
         )
     }
@@ -40,15 +40,18 @@ class TimePickerStateMapper @Inject constructor(
         timePickerState: TimePickerState,
     ) = timePickerState.copy(
         selectedDate = date,
-        selectedDateFormatted = format(date)
+        selectedDateFormatted = dateFormatter.formatUTC(date, DATE_FORMAT)
     )
 
     fun mapInstant(timePickerState: TimePickerState): Instant = with(timePickerState) {
-        val zoneId = ZoneId.of("UTC")
-        val date = selectedDate.atZone(zoneId).toLocalDate()
-        return LocalDateTime.of(date, selectedTime).atZone(zoneId).toInstant()
+        val date = selectedDate.atZone(UTC_ZONE_ID).toLocalDate()
+        return LocalDateTime.of(date, selectedTime).atZone(UTC_ZONE_ID).toInstant()
     }
 
     private fun format(time: LocalTime) = dateFormatter.format(time, DateFormat.HH_MM)
-    private fun format(date: Instant): String = dateFormatter.format(date, DateFormat.MM_DD_YYYY)
+
+    private companion object {
+        val UTC_ZONE_ID: ZoneId = ZoneId.of("UTC")
+        val DATE_FORMAT = DateFormat.MM_DD_YYYY
+    }
 }

--- a/app/src/test/kotlin/edu/stanford/bdh/engagehf/health/time/TimePickerStateMapperTest.kt
+++ b/app/src/test/kotlin/edu/stanford/bdh/engagehf/health/time/TimePickerStateMapperTest.kt
@@ -28,7 +28,9 @@ class TimePickerStateMapperTest {
     fun setup() {
         every { timeProvider.nowInstant() } returns instant
         every { timeProvider.nowLocalTime() } returns time
-        every { dateFormatter.format(instant, DateFormat.MM_DD_YYYY) } returns formattedDate
+        every {
+            dateFormatter.formatDefaultZoneId(instant, DateFormat.MM_DD_YYYY)
+        } returns formattedDate
         every { dateFormatter.format(time, DateFormat.HH_MM) } returns formattedTime
     }
 
@@ -74,7 +76,7 @@ class TimePickerStateMapperTest {
         val state = mapper.mapNow()
         val newDate = Instant.now().plusSeconds(12)
         val formatted = "new-formatted-time"
-        every { dateFormatter.format(newDate, DateFormat.MM_DD_YYYY) } returns formatted
+        every { dateFormatter.formatUTC(newDate, DateFormat.MM_DD_YYYY) } returns formatted
 
         // when
         val result = mapper.mapDate(newDate, state)

--- a/core/utils/src/main/kotlin/edu/stanford/spezi/core/utils/DateFormatter.kt
+++ b/core/utils/src/main/kotlin/edu/stanford/spezi/core/utils/DateFormatter.kt
@@ -10,15 +10,23 @@ import javax.inject.Inject
 class DateFormatter @Inject constructor() {
 
     fun <T : TemporalAccessor> format(date: T, format: DateFormat): String {
-        val zoned = if (date is Instant) {
-            date.atZone(ZoneId.systemDefault())
-        } else {
-            date
-        }
-        return DateTimeFormatter.ofPattern(format.pattern).format(zoned)
+        if (date is Instant) return formatDefaultZoneId(date, format)
+        return DateTimeFormatter.ofPattern(format.pattern).format(date)
+    }
+
+    fun formatUTC(instant: Instant, format: DateFormat): String {
+        return format(instant, format, ZoneId.of("UTC"))
+    }
+
+    fun formatDefaultZoneId(instant: Instant, format: DateFormat): String {
+        return format(instant, format, ZoneId.systemDefault())
     }
 
     fun format(date: Date, format: DateFormat) = format(date.toInstant(), format)
+
+    fun format(instant: Instant, format: DateFormat, zoneId: ZoneId): String {
+        return DateTimeFormatter.ofPattern(format.pattern).format(instant.atZone(zoneId))
+    }
 }
 
 sealed class DateFormat(open val pattern: String) {

--- a/core/utils/src/test/kotlin/edu/stanford/spezi/core/utils/DateFormatterTest.kt
+++ b/core/utils/src/test/kotlin/edu/stanford/spezi/core/utils/DateFormatterTest.kt
@@ -5,7 +5,6 @@ import org.junit.Test
 import java.time.Instant
 import java.time.LocalTime
 import java.time.ZoneId
-import java.util.Date
 
 class DateFormatterTest {
     private val formatter = DateFormatter()
@@ -36,6 +35,46 @@ class DateFormatterTest {
     }
 
     @Test
+    fun `it should format instant in system zone id correctly`() {
+        // given
+        val instant = Instant.parse("2025-01-15T18:45:00Z")
+        val expectedFormat = "01/15/2025"
+
+        // when
+        val result = formatter.formatDefaultZoneId(instant, DateFormat.MM_DD_YYYY)
+
+        // then
+        assertThat(result).isEqualTo(expectedFormat)
+    }
+
+    @Test
+    fun `it should format instant in UTC correctly`() {
+        // given
+        val instant = Instant.parse("2025-01-15T22:00:00-08:00")
+        val expectedFormat = "01/16/2025"
+
+        // when
+        val result = formatter.formatUTC(instant, DateFormat.MM_DD_YYYY)
+
+        // then
+        assertThat(result).isEqualTo(expectedFormat)
+    }
+
+    @Test
+    fun `it should format instant in Los Angeles time zone correctly correctly`() {
+        // given
+        val instant = Instant.parse("2025-01-15T01:00:00Z")
+        val expectedFormat = "01/14/2025"
+        val zoneId = ZoneId.of("America/Los_Angeles")
+
+        // when
+        val result = formatter.format(instant, DateFormat.MM_DD_YYYY, zoneId)
+
+        // then
+        assertThat(result).isEqualTo(expectedFormat)
+    }
+
+    @Test
     fun `it should format zoned date correctly`() {
         // given
         val instantDate = 15
@@ -47,19 +86,6 @@ class DateFormatterTest {
 
         // when
         val result = formatter.format(zoned, DateFormat.MM_DD_YYYY)
-
-        // then
-        assertThat(result).isEqualTo(expectedFormat)
-    }
-
-    @Test
-    fun `it should format date correctly`() {
-        // given
-        val date = Date.from(Instant.parse("2025-01-15T18:45:00Z"))
-        val expectedFormat = "01/15/2025"
-
-        // when
-        val result = formatter.format(date, DateFormat.MM_DD_YYYY)
 
         // then
         assertThat(result).isEqualTo(expectedFormat)


### PR DESCRIPTION
# *Date mapping when manually adding measurements*

## :recycle: Current situation & Problem
- Fixes #165 
- Correction from previous PR: Initial time (now) is being mapped correctly in default zone id, however when receiving a new selected date instant from the date picker, it should be formatted in UTC to reflect the same value as in the picker
- Further adapt the unit tests

## :gear: Release Notes 
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
