### PR TITLE
Delete and recreate encrypted storage file if key store corrupted

### DIFF
--- a/modules/storage/src/main/kotlin/edu/stanford/spezi/modules/storage/key/KeyValueStorageFactory.kt
+++ b/modules/storage/src/main/kotlin/edu/stanford/spezi/modules/storage/key/KeyValueStorageFactory.kt
@@ -42,13 +42,10 @@ internal class KeyValueStorageFactoryImpl @Inject constructor(
             when (type) {
                 KeyValueStorageType.UNENCRYPTED -> createUnencryptedStorage(fileName = fileName)
 
-                KeyValueStorageType.ENCRYPTED -> createEncryptedStorage(fileName = fileName) ?: run {
+                KeyValueStorageType.ENCRYPTED -> createEncryptedStorage(fileName = fileName).getOrNull() ?: run {
                     logger.w { "First encrypted storage creation failed, deleting existing file and retrying..." }
                     context.deleteSharedPreferences(fileName)
-                    createEncryptedStorage(fileName = fileName) ?: run {
-                        logger.w { "Second encrypted storage creation failed, returning a non encrypted file instead" }
-                        createUnencryptedStorage(fileName = fileName)
-                    }
+                    createEncryptedStorage(fileName = fileName).getOrThrow()
                 }
             }
         }
@@ -69,5 +66,5 @@ internal class KeyValueStorageFactoryImpl @Inject constructor(
         )
     }.onSuccess {
         logger.i { "Successfully created encrypted storage $fileName" }
-    }.getOrNull()
+    }
 }


### PR DESCRIPTION
# *Encrypted storage*

## :recycle: Current situation & Problem
I debugged the issue and it appears to happen if the key store used to encrypt the file becomes unavailable or corrupted. This can happen in several occasions such as os version updates or device data backup, and there is unfortunately no way to recover the data in such cases and we have to delete the previous file.

I was able to reproduce the issue in our integration tests: Start the emulator, and run the test suite of `storage` module. The tests produce shared prefs files generated with the key store of the last test session. Closing and relaunching the emulator, and rerunning the same test suite again triggers the crash because the key store signature between test sessions do not match. After the fix we handle this gracefully and recreate the file.

<img width="1719" alt="Screenshot 2025-03-09 at 11 26 55" src="https://github.com/user-attachments/assets/ca6745ec-de03-41b8-924c-647bbd43b2ec" />

<img width="433" alt="Screenshot 2025-03-09 at 11 48 50" src="https://github.com/user-attachments/assets/a624e866-5afa-4c6b-9cd9-16342678e400" />

## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
