### PR TITLE
Spezi theme preview flag

### DIFF
--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/DoNewMeasurementBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/DoNewMeasurementBottomSheet.kt
@@ -103,7 +103,7 @@ enum class DoNewMeasurementBottomSheetTestIdentifier {
 @ThemePreviews
 @Composable
 fun PreviewDoNewMeasurementBottomSheetContent() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         DoNewMeasurementBottomSheet()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/VitalDisplay.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/component/VitalDisplay.kt
@@ -173,7 +173,7 @@ private class VitalDisplayDataProvider : PreviewParameterProvider<VitalDisplayDa
 @Composable
 @Suppress("UnusedPrivateMember")
 private fun VitalDisplayPreview(@PreviewParameter(VitalDisplayDataProvider::class) state: VitalDisplayData) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         VitalDisplay(
             vitalDisplayUiState = state
         )

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/pairing/BLEDevicePairingBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/bluetooth/pairing/BLEDevicePairingBottomSheet.kt
@@ -119,7 +119,7 @@ private class UIStateParamProvider : PreviewParameterProvider<BLEDevicePairingVi
 fun PreviewBLEDevicePairingBottomSheet(
     @PreviewParameter(UIStateParamProvider::class) state: BLEDevicePairingViewModel.UiState,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         BLEDevicePairingBottomSheet(
             uiState = state,
             onAction = {},

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthPage.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/HealthPage.kt
@@ -300,7 +300,7 @@ private class HealthPagePreviewProvider : PreviewParameterProvider<HealthUiState
 @ThemePreviews
 @Composable
 private fun HealthPagePreview(@PreviewParameter(HealthPagePreviewProvider::class) uiState: HealthUiState) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         HealthPage(
             uiState = uiState,
             onAction = {}

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/BloodPressureDescriptionBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/BloodPressureDescriptionBottomSheet.kt
@@ -50,7 +50,7 @@ fun BloodPressureDescriptionBottomSheet() {
 @ThemePreviews
 @Composable
 fun BloodPressureDescriptionBottomSheetPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         BloodPressureDescriptionBottomSheet()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/BodyPositionDialog.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/BodyPositionDialog.kt
@@ -33,7 +33,7 @@ fun BodyPositionsDialog(
 @ThemePreviews
 @Composable
 fun BodyPositionsDialogPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         BodyPositionsDialog(
             onDismissRequest = {},
             onOptionSelected = {},

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/MeasurementLocationDialog.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/bloodpressure/bottomsheet/MeasurementLocationDialog.kt
@@ -41,7 +41,7 @@ fun MeasurementLocationDialog(
 @ThemePreviews
 @Composable
 fun MeasurementLocationDialogPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         MeasurementLocationDialog(
             onDismissRequest = {},
             onOptionSelected = {},

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/ItemsDialog.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/ItemsDialog.kt
@@ -59,7 +59,7 @@ fun ItemsDialog(
 @ThemePreviews
 @Composable
 private fun BodyPositionsDialogPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ItemsDialog(
             title = "Title",
             items = listOf("Item 1", "Item 2", "Item 3"),

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/NumberPicker.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/NumberPicker.kt
@@ -73,7 +73,7 @@ fun NumberPicker(
 @ThemePreviews
 @Composable
 fun NumberPickerPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         NumberPicker(
             value = 5,
             onValueChange = {},

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/TimeRangeDropdown.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/components/TimeRangeDropdown.kt
@@ -73,7 +73,7 @@ fun TimeRangeDropdown(
 @ThemePreviews
 @Composable
 fun MenuSamplePreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         TimeRangeDropdown(
             modifier = Modifier.fillMaxWidth(),
             isSelectedTimeRangeDropdownExpanded = true,

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/heartrate/bottomsheet/HeartRateDescriptionBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/heartrate/bottomsheet/HeartRateDescriptionBottomSheet.kt
@@ -50,7 +50,7 @@ fun HeartRateDescriptionBottomSheet() {
 @ThemePreviews
 @Composable
 fun HeartRateDescriptionBottomSheetPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         HeartRateDescriptionBottomSheet()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/symptoms/SymptomsDescriptionBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/symptoms/SymptomsDescriptionBottomSheet.kt
@@ -83,7 +83,7 @@ fun TitleDescriptionItem(title: String, description: String) {
 @ThemePreviews
 @Composable
 fun SymptomsDescriptionBottomSheetPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         SymptomsDescriptionBottomSheet()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/weight/bottomsheet/AddWeightBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/weight/bottomsheet/AddWeightBottomSheet.kt
@@ -124,7 +124,7 @@ private class AddWeightBottomSheetStepProvider :
 fun AddWeightBottomSheetPreview(
     @PreviewParameter(AddWeightBottomSheetStepProvider::class) uiState: AddWeightBottomSheetUiState,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         AddWeightBottomSheet(uiState = uiState, onAction = {})
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/weight/bottomsheet/WeightDescriptionBottomSheet.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/health/weight/bottomsheet/WeightDescriptionBottomSheet.kt
@@ -50,7 +50,7 @@ fun WeightDescriptionBottomSheet() {
 @ThemePreviews
 @Composable
 private fun WeightDescriptionBottomSheetPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         WeightDescriptionBottomSheet()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/ColorKey.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/ColorKey.kt
@@ -76,7 +76,7 @@ fun ColorKeyRow(color: MedicationColor) {
 @ThemePreviews
 @Composable
 private fun ColorKeyPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ColorKey()
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/DosageInformation.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/DosageInformation.kt
@@ -71,7 +71,7 @@ private class DosageInformationProvider : PreviewParameterProvider<DosageInforma
 private fun DoseInformationPreview(
     @PreviewParameter(DosageInformationProvider::class) dosageInformation: DosageInformationUiModel,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         DosageInformation(dosageInformationUiModel = dosageInformation)
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationCard.kt
@@ -186,7 +186,7 @@ fun LoadingMedicationSection() {
 @ThemePreviews
 @Composable
 private fun LoadingMedicationSectionPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         LoadingMedicationSection()
     }
 }
@@ -196,7 +196,7 @@ private fun LoadingMedicationSectionPreview() {
 private fun MedicationCardPreview(
     @PreviewParameter(MedicationCardModelsProvider::class) model: MedicationCardUiModel,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         MedicationCard(
             model = model,
             onAction = {}

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationProgressBar.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationProgressBar.kt
@@ -74,7 +74,7 @@ private class MedicationProgressBarProvider : PreviewParameterProvider<Float> {
 private fun MedicationProgressBarPreview(
     @PreviewParameter(MedicationProgressBarProvider::class) progress: Float,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         MedicationProgressBar(progress = progress)
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationStatusIcon.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/medication/components/MedicationStatusIcon.kt
@@ -50,7 +50,7 @@ fun MedicationStatusIcon(model: MedicationCardUiModel) {
 private fun MedicationStatusIconPreview(
     @PreviewParameter(MedicationCardModelsProvider::class) model: MedicationCardUiModel,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         MedicationStatusIcon(model = model)
     }
 }

--- a/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageItem.kt
+++ b/app/src/main/kotlin/edu/stanford/bdh/engagehf/messages/MessageItem.kt
@@ -182,7 +182,7 @@ enum class MessageItemTestIdentifiers {
 @Composable
 @ThemePreviews
 fun MessageListPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         LazyColumn(modifier = Modifier.padding(Spacings.medium)) {
             items(sampleMessageModels) { model ->
                 MessageItem(model = model, onAction = { })

--- a/contact/src/main/kotlin/edu/stanford/spezi/contact/AddressCard.kt
+++ b/contact/src/main/kotlin/edu/stanford/spezi/contact/AddressCard.kt
@@ -78,7 +78,7 @@ internal fun AddressCard(address: Address, modifier: Modifier = Modifier) {
 @Composable
 @ThemePreviews
 private fun AddressCardPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         AddressCard(Address(Locale.US).apply {
             setAddressLine(0, "1234 Main Street")
             postalCode = "12345"

--- a/contact/src/main/kotlin/edu/stanford/spezi/contact/ContactComposable.kt
+++ b/contact/src/main/kotlin/edu/stanford/spezi/contact/ContactComposable.kt
@@ -139,7 +139,7 @@ enum class ContactComposableTestIdentifier {
 @ThemePreviews
 @Composable
 private fun ContactComposablePreview(@PreviewParameter(ContactProvider::class) contact: Contact) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ContactComposable(contact = contact)
     }
 }

--- a/contact/src/main/kotlin/edu/stanford/spezi/contact/ContactOptionCard.kt
+++ b/contact/src/main/kotlin/edu/stanford/spezi/contact/ContactOptionCard.kt
@@ -53,7 +53,7 @@ internal fun ContactOptionCard(option: ContactOption, modifier: Modifier = Modif
 @Composable
 @ThemePreviews
 private fun ContactOptionCardPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ContactOptionCard(
             ContactOption.email(
                 addresses = listOf("test@test.de"),

--- a/modules/account/src/main/kotlin/edu/stanford/spezi/modules/account/login/components/SignInWithGoogleButton.kt
+++ b/modules/account/src/main/kotlin/edu/stanford/spezi/modules/account/login/components/SignInWithGoogleButton.kt
@@ -43,7 +43,7 @@ fun SignInWithGoogleButton(
 @ThemePreviews
 @Composable
 fun SignInWithGoogleButtonPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         SignInWithGoogleButton(onButtonClick = {})
     }
 }

--- a/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/AsyncImageResourceComposable.kt
+++ b/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/AsyncImageResourceComposable.kt
@@ -102,7 +102,7 @@ fun AsyncImageResourceComposable(
 private fun ImageResourceComposablePreview(
     @PreviewParameter(AsyncImageResourceProvider::class) imageResource: ImageResource,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ImageResourceComposable(
             imageResource = imageResource,
         )

--- a/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/AsyncSwitch.kt
+++ b/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/AsyncSwitch.kt
@@ -64,7 +64,7 @@ private data class AsyncSwitchState(
 private fun AsyncSwitchPreview(
     @PreviewParameter(AsyncSwitchPreviewParameterProvider::class) state: AsyncSwitchState,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         AsyncSwitch(
             isLoading = state.isLoading,
             checked = state.checked,

--- a/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/ShimmerEffect.kt
+++ b/modules/design/src/main/kotlin/edu/stanford/spezi/modules/design/component/ShimmerEffect.kt
@@ -127,7 +127,7 @@ fun Modifier.height(textStyle: TextStyle) = then(Modifier.height(textStyle.fontS
 @ThemePreviews
 @Composable
 fun ShimmerEffectPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/ui-markdown/src/main/kotlin/edu/stanford/spezi/ui/markdown/Markdown.kt
+++ b/ui-markdown/src/main/kotlin/edu/stanford/spezi/ui/markdown/Markdown.kt
@@ -83,7 +83,7 @@ fun Markdown(
 @ThemePreviews
 @Composable
 private fun MarkdownPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         MarkdownString("This is a markdown **example**!")
     }
 }

--- a/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/NameFieldRow.kt
+++ b/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/NameFieldRow.kt
@@ -57,7 +57,7 @@ fun NameFieldRow(
 private fun NameFieldRowPreview() {
     val nameBuilder = remember { PersonNameComponents.Builder() }
 
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         Column {
             NameFieldRow(
                 nameBuilder,

--- a/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/NameTextField.kt
+++ b/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/NameTextField.kt
@@ -67,7 +67,7 @@ fun NameTextField(
 private fun NameTextFieldPreview() {
     val name = remember { PersonNameComponents.Builder() }
 
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         NameTextField(name, PersonNameComponents.Builder::givenName) {
             Text("Enter first name")
         }

--- a/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/UserProfileComposable.kt
+++ b/ui-personalinfo/src/main/kotlin/edu/stanford/spezi/ui/personalinfo/UserProfileComposable.kt
@@ -117,7 +117,7 @@ private class UserProfileProvider : PreviewParameterProvider<UserProfilePreviewD
 private fun UserProfileComposablePreview(
     @PreviewParameter(UserProfileProvider::class) profileData: UserProfilePreviewData,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         UserProfileComposable(
             name = profileData.first,
             imageLoader = profileData.second,

--- a/ui-validation/src/main/kotlin/edu/stanford/spezi/ui/validation/ValidationResultsComposable.kt
+++ b/ui-validation/src/main/kotlin/edu/stanford/spezi/ui/validation/ValidationResultsComposable.kt
@@ -29,7 +29,7 @@ fun ValidationResultsComposable(
 @ThemePreviews
 @Composable
 private fun ValidationResultsComposablePreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ValidationResultsComposable(
             listOf(
                 FailedValidationResult(ValidationRule.nonEmpty),

--- a/ui-validation/src/main/kotlin/edu/stanford/spezi/ui/validation/VerifiableTextField.kt
+++ b/ui-validation/src/main/kotlin/edu/stanford/spezi/ui/validation/VerifiableTextField.kt
@@ -131,7 +131,7 @@ fun VerifiableTextField(
 private fun VerifiableTextFieldPreview() {
     val text = remember { mutableStateOf("") }
 
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         Validate(text.value, rules = listOf(ValidationRule.nonEmpty)) {
             VerifiableTextField(
                 text,

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/DescriptionGridRow.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/DescriptionGridRow.kt
@@ -46,7 +46,7 @@ fun DescriptionGridRow(
 @ThemePreviews
 @Composable
 private fun DescriptionGridRowPreviews() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         Column {
             DescriptionGridRow(description = {
                 Text("Description")

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/ImageResourceComposable.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/ImageResourceComposable.kt
@@ -46,7 +46,7 @@ fun ImageResourceComposable(
 private fun ImageResourceComposablePreview(
     @PreviewParameter(ImageResourceProvider::class) imageResource: ImageResource,
 ) {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ImageResourceComposable(
             imageResource = imageResource,
         )

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/ProcessingOverlay.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/ProcessingOverlay.kt
@@ -57,7 +57,7 @@ fun ProcessingOverlay(
 @ThemePreviews
 @Composable
 private fun ProcessingOverlayPreview() {
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ProcessingOverlay(true) {
             SuspendButton("Do something") {
                 println("Did something")

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/SpeziKtTheme.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/SpeziKtTheme.kt
@@ -14,6 +14,7 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -51,7 +52,6 @@ private val LightColorScheme = lightColorScheme(
 fun SpeziTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
     dynamicColor: Boolean = true,
-    isPreview: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val colorScheme = when {
@@ -71,7 +71,7 @@ fun SpeziTheme(
             WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
         }
     }
-
+    val isPreview = LocalInspectionMode.current
     val surface: ComposableBlock = {
         Surface(
             modifier = if (isPreview) Modifier else Modifier.fillMaxSize(),

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/SuspendButton.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/SuspendButton.kt
@@ -81,7 +81,7 @@ fun SuspendButton(
 @Composable
 private fun SuspendButtonPreview() {
     val state = remember { mutableStateOf<ViewState>(ViewState.Idle) }
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         SuspendButton("Test Button", state) {
             throw NotImplementedError()
         }

--- a/ui/src/main/kotlin/edu/stanford/spezi/ui/ViewStateAlert.kt
+++ b/ui/src/main/kotlin/edu/stanford/spezi/ui/ViewStateAlert.kt
@@ -51,7 +51,7 @@ fun ViewStateAlert(
 private fun ViewStateAlertPreview() {
     val state = remember { mutableStateOf<ViewState>(ViewState.Error(NotImplementedError())) }
 
-    SpeziTheme(isPreview = true) {
+    SpeziTheme {
         ViewStateAlert(state)
     }
 }


### PR DESCRIPTION
# *Spezi theme preview flag*

## :recycle: Current situation & Problem
- A find & replace task: remove explicit `isPreview` flag from the theme, and use `LocalInspectionMode` instead - compose set's it internally to true for `@Preview`s
- Pointing to #192 as a separate PR to keep isolated from it's changes


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
