### PR TITLE
Expand education video sections by default

### DIFF
--- a/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenTest.kt
+++ b/modules/education/src/androidTest/java/edu/stanford/spezi/modules/education/videos/EducationScreenTest.kt
@@ -76,8 +76,7 @@ class EducationScreenTest {
         description: String = "description",
         orderIndex: Int = 0,
         videos: List<Video> = listOf(createDefaultVideo()),
-        isExpanded: Boolean = true,
-    ): VideoSection = VideoSection(title, description, orderIndex, videos, isExpanded)
+    ): VideoSection = VideoSection(title, description, orderIndex, videos)
 
     private fun createDefaultEducationUiState(
         videoSections: List<VideoSection> = listOf(createDefaultVideoSection()),

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationScreen.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationScreen.kt
@@ -94,10 +94,6 @@ fun EducationScreen(
                         title = videoSection.title,
                         description = videoSection.description,
                         videos = videoSection.videos,
-                        expandedStartValue = videoSection.isExpanded,
-                        onExpand = {
-                            onAction(Action.OnExpand(videoSection))
-                        },
                         onActionClick = { video ->
                             onAction(
                                 Action.VideoSectionClicked(

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationUiState.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationUiState.kt
@@ -18,7 +18,6 @@ data class VideoSection(
     val description: String,
     val orderIndex: Int = 0,
     val videos: List<Video> = emptyList(),
-    var isExpanded: Boolean = false,
 )
 
 @Serializable
@@ -36,7 +35,6 @@ internal const val VIDEO_SAVE_STATE_PARAM = "video"
 
 sealed interface Action {
     data class VideoSectionClicked(val video: Video) : Action
-    data class OnExpand(val videoSection: VideoSection) : Action
 
     data object Retry : Action
 }

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationViewModel.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/EducationViewModel.kt
@@ -11,7 +11,6 @@ import edu.stanford.spezi.modules.navigation.Navigator
 import edu.stanford.spezi.ui.StringResource
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -36,20 +35,14 @@ internal class EducationViewModel @Inject constructor(
                 _uiState.value =
                     UiState.Error(StringResource(R.string.failed_to_load_video_sections))
             }.onSuccess { videoSections ->
-                _uiState.value = UiState.Success(EducationUiState(videoSections = videoSections))
+                _uiState.value = UiState.Success(EducationUiState(videoSections = videoSections.sortedBy { it.orderIndex }))
             }
         }
     }
 
-    private fun retry() {
-        loadVideoSections()
-    }
-
     fun onAction(action: Action) {
         when (action) {
-            is Action.Retry -> {
-                retry()
-            }
+            is Action.Retry -> loadVideoSections()
 
             is Action.VideoSectionClicked -> {
                 navigator.navigateTo(
@@ -57,24 +50,6 @@ internal class EducationViewModel @Inject constructor(
                         video = action.video
                     )
                 )
-            }
-
-            is Action.OnExpand -> _uiState.update { currentState ->
-                if (currentState is UiState.Success) {
-                    currentState.copy(data = currentState.data.copy(
-                        videoSections = currentState.data.videoSections.map { videoSection ->
-                            if (videoSection == action.videoSection) {
-                                videoSection.copy(
-                                    isExpanded = !videoSection.isExpanded
-                                )
-                            } else {
-                                videoSection
-                            }
-                        }
-                    ))
-                } else {
-                    currentState
-                }
             }
         }
     }

--- a/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/component/ExpandableVideoSection.kt
+++ b/modules/education/src/main/java/edu/stanford/spezi/modules/education/videos/component/ExpandableVideoSection.kt
@@ -28,7 +28,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -56,40 +56,15 @@ private const val IMAGE_HEIGHT = 200
 private const val ASPECT_16_9 = 16f / 9f
 
 @Composable
-internal fun SectionHeader(
-    text: String?,
-    isExpanded: Boolean,
-    onHeaderClicked: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clickable { onHeaderClicked() }
-            .padding(Spacings.medium),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween
-    ) {
-        text?.let {
-            Text(
-                text = it,
-                style = titleLarge
-            )
-        }
-        ExpandIcon(isExpanded)
-    }
-}
-
-@Composable
 internal fun ExpandableVideoSection(
     modifier: Modifier = Modifier,
-    title: String?,
+    title: String,
     description: String?,
     videos: List<Video> = emptyList(),
-    expandedStartValue: Boolean = false,
-    onExpand: () -> Unit = {},
+    expandedStartValue: Boolean = true,
     onActionClick: (Video) -> Unit = { _ -> },
 ) {
-    var expanded by remember { mutableStateOf(expandedStartValue) }
+    var expanded by rememberSaveable { mutableStateOf(expandedStartValue) }
 
     VideoElevatedCard(
         modifier = modifier
@@ -103,10 +78,6 @@ internal fun ExpandableVideoSection(
             SectionHeader(
                 text = title,
                 isExpanded = expanded,
-                onHeaderClicked = {
-                    expanded = !expanded
-                    onExpand()
-                }
             )
 
             description?.let {
@@ -139,6 +110,29 @@ internal fun ExpandableVideoSection(
                 }
             }
         }
+    }
+}
+
+@Composable
+private fun SectionHeader(
+    text: String,
+    isExpanded: Boolean,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(Spacings.medium),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            text = text,
+            style = titleLarge
+        )
+        Icon(
+            imageVector = if (isExpanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown,
+            contentDescription = null,
+        )
     }
 }
 
@@ -228,24 +222,12 @@ private fun VideoElevatedCard(
     )
 }
 
-@Composable
-internal fun ExpandIcon(expanded: Boolean) {
-    val vector = if (expanded) Icons.Filled.KeyboardArrowUp else Icons.Filled.KeyboardArrowDown
-    Icon(
-        imageVector = vector,
-        contentDescription = null,
-    )
-}
-
-private class ExpandableSectionPreviewProvider :
-    PreviewParameterProvider<ExpandableVideoSectionParams> {
+private class ExpandableSectionPreviewProvider : PreviewParameterProvider<ExpandableVideoSectionParams> {
     val factory = ExpandableVideoSectionParamsFactory()
     override val values: Sequence<ExpandableVideoSectionParams> = sequenceOf(
         factory.createParams(),
         factory.createParams().copy(expandedStartValue = true),
     )
-
-    override val count: Int = values.count()
 }
 
 @ThemePreviews
@@ -265,7 +247,7 @@ private fun ExpandableVideoSectionPreview(
 }
 
 private data class ExpandableVideoSectionParams(
-    val title: String?,
+    val title: String,
     val description: String?,
     val content: @Composable () -> Unit,
     val expandedStartValue: Boolean = false,
@@ -273,7 +255,7 @@ private data class ExpandableVideoSectionParams(
 
 private class ExpandableVideoSectionParamsFactory {
     fun createParams(
-        title: String? = "Title",
+        title: String = "Title",
         description: String? = "Description",
         content: @Composable () -> Unit = { Text(text = "Content") },
         expandedStartValue: Boolean = false,


### PR DESCRIPTION
# *Expand education video sections by default*

## :recycle: Current situation & Problem
- Fixes [#2](https://github.com/StanfordBDHG/ENGAGE-HF-Android/issues/2)
- Minor composable adjustments
- Add missing sort of video sections based on order index and unit test


## :gear: Release Notes
*Add a bullet point list summary of the feature and possible migration guides if this is a breaking change so this section can be added to the release notes.*
*Include code snippets that provide examples of the feature implemented or links to the documentation if it appends or changes the public interface.*


## :books: Documentation
*Please ensure that you properly document any additions in conformance to [Spezi Documentation Guide](https://github.com/StanfordSpezi/.github/blob/main/DOCUMENTATIONGUIDE.md).*
*You can use this section to describe your solution, but we encourage contributors to document your reasoning and changes using in-line documentation.* 


## :white_check_mark: Testing
*Please ensure that the PR meets the testing requirements set by CodeCov and that new functionality is appropriately tested.*
*This section describes important information about the tests and why some elements might not be testable.*


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
