### PR TITLE
Replaced Signature Canvas with new androidx.Ink Api

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,5 +79,8 @@ dependencies {
 
     implementation(libs.googlecode.phonenumber)
 
+    implementation(libs.androidx.ink.authoring)
+    implementation(libs.androidx.ink.strokes)
+
     androidTestImplementation(project(":modules:testing"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,12 +2,12 @@
 [versions]
 accompanistPager = "0.35.1-alpha"
 activityCompose = "1.9.0"
-agp = "8.5.0"
+agp = "8.9.1"
 androidTools = "31.5.0"
 androidyoutubeplayer-core = "12.1.0"
 appcompat = "1.7.0"
 coilCompose = "2.6.0"
-compileSdk = "34"
+compileSdk = "35"
 composeBom = "2024.06.00"
 composeNavigation = "2.8.0-beta03"
 coreI18n = "1.0.0-alpha01"
@@ -35,6 +35,13 @@ guava = "32.1.3-android" # is a fixed version which works with all other depende
 healthConnectClient = "1.1.0-alpha07"
 hiltNavigation = "1.2.0"
 hiltVersion = "2.51"
+inkAuthoring = "1.0.0-alpha01"
+inkBrush = "1.0.0-alpha01"
+inkCore = "1.0.0-alpha02"
+inkGeometry = "1.0.0-alpha01"
+inkNativeloader = "1.0.0-alpha01"
+inkRendering = "1.0.0-alpha01"
+inkStrokes = "1.0.0-alpha01"
 junit = "4.13.2"
 junitVersion = "1.1.5"
 kotlin = "2.0.0"
@@ -50,12 +57,16 @@ rulesVersion = "1.5.0"
 runnerVersion = "1.5.2"
 securityCryptoKtx = "1.1.0-alpha06"
 splashScreenVersion = "1.0.1"
-targetSdk = "34"
+targetSdk = "35"
 testCoreVersion = "1.5.0"
 timberVersion = "5.0.1"
 truth = "1.4.2"
 vico = "2.0.0-alpha.26"
 zxingVersion = "3.5.0"
+inkAuthoringAndroid = "1.0.0-alpha04"
+inputMotionprediction = "1.0.0-beta05"
+inkStrokesAndroid = "1.0.0-alpha04"
+digitalInkRecognition = "18.1.0"
 
 # Please keep [libraries] block sorted. Select all items and in Android Studio `Edit > Sort Lines`
 [libraries]
@@ -74,6 +85,13 @@ androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-co
 androidx-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
 androidx-fragment-compose = { module = "androidx.fragment:fragment-compose", version.ref = "fragmentCompose" }
 androidx-health-connect-client = { module = "androidx.health.connect:connect-client", version.ref = "healthConnectClient" }
+androidx-ink-authoring = { module = "androidx.ink:ink-authoring", version.ref = "inkAuthoring" }
+androidx-ink-core = { module = "androidx.ink:ink-core", version.ref = "inkCore" }
+androidx-ink-geometry = { module = "androidx.ink:ink-geometry", version.ref = "inkGeometry" }
+androidx-ink-brush = { module = "androidx.ink:ink-brush", version.ref = "inkBrush" }
+androidx-ink-rendering = { module = "androidx.ink:ink-rendering", version.ref = "inkRendering" }
+androidx-ink-nativeloader = { module = "androidx.ink:ink-nativeloader", version.ref = "inkNativeloader" }
+androidx-ink-strokes = { module = "androidx.ink:ink-strokes", version.ref = "inkStrokes" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycleKtx" }
 androidx-lifecycle-view-model-ktx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "lifecycleKtx" }
@@ -126,6 +144,10 @@ play-services-auth = { group = "com.google.android.gms", name = "play-services-a
 timber = { group = "com.jakewharton.timber", name = "timber", version.ref = "timberVersion" }
 vico-compose-m3 = { group = "com.patrykandpatrick.vico", name = "compose-m3", version.ref = "vico" }
 zxing-core = { group = "com.google.zxing", name = "core", version.ref = "zxingVersion" }
+androidx-ink-authoring-android = { group = "androidx.ink", name = "ink-authoring-android", version.ref = "inkAuthoringAndroid" }
+androidx-input-motionprediction = { group = "androidx.input", name = "input-motionprediction", version.ref = "inputMotionprediction" }
+androidx-ink-strokes-android = { group = "androidx.ink", name = "ink-strokes-android", version.ref = "inkStrokesAndroid" }
+digital-ink-recognition = { group = "com.google.mlkit", name = "digital-ink-recognition", version.ref = "digitalInkRecognition" }
 
 # Please keep [plugins] block sorted. Select all items and in Android Studio `Edit > Sort Lines`
 [plugins]

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Apr 18 21:37:46 CEST 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/modules/notification/src/main/kotlin/edu/stanford/spezi/modules/notification/fcm/DeviceRegistrationService.kt
+++ b/modules/notification/src/main/kotlin/edu/stanford/spezi/modules/notification/fcm/DeviceRegistrationService.kt
@@ -52,7 +52,7 @@ internal class DeviceRegistrationServiceImpl @Inject constructor(
         val body = NotificationTokenBody(
             notificationToken = token,
             osVersion = buildInfo.getOsVersion(),
-            appVersion = packageInfo.versionName,
+            appVersion = packageInfo.versionName!!,
             appBuild = packageInfo.versionCode.toString(),
             language = Locale.getDefault().toLanguageTag(),
             timeZone = TimeZone.getDefault().id

--- a/modules/onboarding/build.gradle.kts
+++ b/modules/onboarding/build.gradle.kts
@@ -24,8 +24,17 @@ dependencies {
     implementation(libs.androidx.foundation)
     implementation(libs.accompanist.pager)
     implementation(libs.hilt.navigation.compose)
+    implementation(libs.androidx.input.motionprediction)
+    implementation(libs.digital.ink.recognition)
 
     testImplementation(libs.bundles.unit.testing)
 
     androidTestImplementation(libs.bundles.compose.androidTest)
+
+    implementation(libs.androidx.ink.authoring)
+    implementation(libs.androidx.ink.brush)
+    implementation(libs.androidx.ink.geometry)
+    implementation(libs.androidx.ink.nativeloader)
+    implementation(libs.androidx.ink.rendering)
+    implementation(libs.androidx.ink.strokes)
 }

--- a/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentScreen.kt
+++ b/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -72,7 +71,7 @@ private class ConsentScreenPreviewProvider : PreviewParameterProvider<ConsentUiS
         ConsentUiState(
             firstName = FieldState("John"),
             lastName = FieldState("Doe"),
-            paths = mutableListOf(Path().apply { lineTo(100f, 100f) }),
+            paths = mutableListOf(),
             markdownElements = listOf(
                 MarkdownElement.Heading(1, "Consent"),
                 MarkdownElement.Paragraph("Please sign below to indicate your consent."),

--- a/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentUiState.kt
+++ b/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentUiState.kt
@@ -1,12 +1,13 @@
 package edu.stanford.spezi.modules.onboarding.consent
 
-import androidx.compose.ui.graphics.Path
+import androidx.ink.authoring.InProgressStrokeId
+import androidx.ink.strokes.Stroke
 import edu.stanford.spezi.ui.markdown.MarkdownElement
 
 data class ConsentUiState(
     val firstName: FieldState = FieldState(value = "", error = false),
     val lastName: FieldState = FieldState(value = "", error = false),
-    val paths: List<Path> = emptyList(),
+    val paths: List<Pair<InProgressStrokeId, Stroke>> = emptyList(),
     val markdownElements: List<MarkdownElement> = emptyList(),
 ) {
     val isValidForm: Boolean =
@@ -24,7 +25,8 @@ enum class TextFieldType {
 
 sealed interface ConsentAction {
     data class TextFieldUpdate(val newValue: String, val type: TextFieldType) : ConsentAction
-    data class AddPath(val path: Path) : ConsentAction
-    data object Undo : ConsentAction
+    data class AddPath(val paths: Map<InProgressStrokeId, Stroke>) : ConsentAction
+    data object UndoPath : ConsentAction
+    data object ClearPath: ConsentAction
     data object Consent : ConsentAction
 }

--- a/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentViewModel.kt
+++ b/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentViewModel.kt
@@ -47,15 +47,18 @@ internal class ConsentViewModel @Inject internal constructor(
             }
 
             is ConsentAction.AddPath -> {
-                _uiState.update { it.copy(paths = it.paths + action.path) }
+                _uiState.update { it.copy(paths = it.paths + action.paths.toList()) }
             }
 
-            is ConsentAction.Undo -> {
+            is ConsentAction.UndoPath -> {
                 _uiState.update { it.copy(paths = it.paths.dropLast(1)) }
             }
 
             is ConsentAction.Consent -> {
                 onConsentAction()
+            }
+            is ConsentAction.ClearPath -> {
+                _uiState.update { it.copy(paths = emptyList()) }
             }
         }
     }

--- a/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/SignatureCanvas.kt
+++ b/modules/onboarding/src/main/kotlin/edu/stanford/spezi/modules/onboarding/consent/SignatureCanvas.kt
@@ -3,119 +3,189 @@ package edu.stanford.spezi.modules.onboarding.consent
 
 import android.graphics.Paint
 import android.view.MotionEvent
+import android.view.View
+import android.widget.FrameLayout
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Path
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.drawIntoCanvas
 import androidx.compose.ui.graphics.nativeCanvas
-import androidx.compose.ui.input.pointer.pointerInteropFilter
-import androidx.compose.ui.layout.onSizeChanged
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.ink.authoring.InProgressStrokeId
+import androidx.ink.authoring.InProgressStrokesFinishedListener
+import androidx.ink.authoring.InProgressStrokesView
+import androidx.ink.brush.Brush
+import androidx.ink.brush.StockBrushes
+import androidx.ink.strokes.Stroke
+import androidx.input.motionprediction.MotionEventPredictor
+
 
 @ExperimentalComposeUiApi
 @Composable
 internal fun SignatureCanvas(
-    paths: MutableList<Path>,
     firstName: String,
     lastName: String,
-    onPathAdd: (Path) -> Unit,
+    onPathAdd: (Map<InProgressStrokeId, Stroke>) -> Unit,
+    onViewCreated: (InProgressStrokesView) -> Unit = {}
 ) {
-    if (paths.isEmpty()) {
-        paths.add(Path())
+
+    val currentPointerId = remember { mutableStateOf<Int?>(null) }
+    val currentStrokeId = remember { mutableStateOf<InProgressStrokeId?>(null) }
+
+    val defaultBrush = Brush.createWithColorIntArgb(
+        family = StockBrushes.pressurePenLatest,
+        colorIntArgb = Color.Black.toArgb(),
+        size = 5F,
+        epsilon = 0.1F
+    )
+
+    val finishedListener = object : InProgressStrokesFinishedListener {
+        override fun onStrokesFinished(strokes: Map<InProgressStrokeId, Stroke>) {
+            onPathAdd(strokes)
+        }
     }
-    val currentPath = paths.last()
-    val movePath = remember { mutableStateOf<Offset?>(null) }
-    val canvasSize = remember { mutableStateOf(IntSize.Zero) }
 
-    Canvas(
-        modifier = Modifier
-            .fillMaxWidth()
-            .height(150.dp)
-            .background(Color.White)
-            .onSizeChanged { size -> canvasSize.value = size }
-            .pointerInteropFilter {
-                when (it.action) {
-                    MotionEvent.ACTION_DOWN -> {
-                        if (it.x in 0f..canvasSize.value.width.toFloat() && it.y in 0f..canvasSize.value.height.toFloat()) {
-                            currentPath.moveTo(it.x, it.y)
+    Box(modifier = Modifier
+        .fillMaxWidth()
+        .background(Color.White)
+        .height(150.dp),) {
+        AndroidView(
+            modifier = Modifier.fillMaxSize(),
+            factory = { ctx ->
+                // Create a new FrameLayout that will be our root view
+                val rootView = FrameLayout(ctx)
+
+                // Create a new InProgressStrokesView instance every time
+                val inProgressStrokesView = InProgressStrokesView(ctx).apply {
+                    layoutParams = FrameLayout.LayoutParams(
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                        FrameLayout.LayoutParams.MATCH_PARENT,
+                    )
+                }
+
+                onViewCreated(inProgressStrokesView)
+
+                inProgressStrokesView.addFinishedStrokesListener(finishedListener)
+
+                val predictor = MotionEventPredictor.newInstance(rootView)
+                val touchListener = View.OnTouchListener { view, event ->
+                    predictor.record(event)
+                    val predictedEvent = predictor.predict()
+
+                    try {
+                        when (event.actionMasked) {
+                            MotionEvent.ACTION_DOWN -> {
+                                // First pointer - treat it as inking.
+                                view.requestUnbufferedDispatch(event)
+                                val pointerIndex = event.actionIndex
+                                val pointerId = event.getPointerId(pointerIndex)
+                                currentPointerId.value = pointerId
+                                currentStrokeId.value =
+                                    inProgressStrokesView.startStroke(
+                                        event = event,
+                                        pointerId = pointerId,
+                                        brush = defaultBrush
+                                    )
+                                true
+                            }
+
+                            MotionEvent.ACTION_MOVE -> {
+                                val pointerId = checkNotNull(currentPointerId.value)
+                                val strokeId = checkNotNull(currentStrokeId.value)
+
+                                for (pointerIndex in 0 until event.pointerCount) {
+                                    if (event.getPointerId(pointerIndex) != pointerId) continue
+                                    inProgressStrokesView.addToStroke(
+                                        event,
+                                        pointerId,
+                                        strokeId,
+                                        predictedEvent
+                                    )
+                                }
+                                true
+                            }
+
+                            MotionEvent.ACTION_UP -> {
+                                val pointerIndex = event.actionIndex
+                                val pointerId = event.getPointerId(pointerIndex)
+                                val strokeId = checkNotNull(currentStrokeId.value)
+                                inProgressStrokesView.finishStroke(
+                                    event,
+                                    pointerId,
+                                    strokeId
+                                )
+                                view.performClick()
+                                true
+                            }
+
+                            MotionEvent.ACTION_CANCEL -> {
+                                val currentStrokeId = checkNotNull(currentStrokeId.value)
+                                inProgressStrokesView.cancelStroke(currentStrokeId, event)
+                                true
+                            }
+
+                            else -> false
                         }
-                    }
-
-                    MotionEvent.ACTION_MOVE -> {
-                        if (it.x in 0f..canvasSize.value.width.toFloat() && it.y in 0f..canvasSize.value.height.toFloat()) {
-                            movePath.value = Offset(it.x, it.y)
-                            onPathAdd(currentPath)
-                        }
-                    }
-
-                    else -> {
-                        movePath.value = null
+                    } finally {
+                        predictedEvent?.recycle()
                     }
                 }
-                true
-            }
-    ) {
-        movePath.value?.let {
-            currentPath.lineTo(it.x, it.y)
-            drawPath(
-                path = currentPath,
-                color = Color.Black,
-                style = Stroke(10f)
-            )
-        }
 
-        paths.forEach {
-            drawPath(
-                path = it,
-                color = Color.Black,
-                style = Stroke(10f)
-            )
-        }
+                rootView.setOnTouchListener(touchListener)
+                rootView.addView(inProgressStrokesView)
 
-        drawLine(
+                rootView
+            },
+        )
+
+        Canvas(
+            modifier = Modifier.fillMaxSize()
+        ) {
+            val lineY = size.height - 50f
+            drawLine(
+                start = Offset(x = 10f, y = lineY),
+                end = Offset(x = size.width - 10f, y = lineY),
+                color = Color.Gray,
+                strokeWidth = 2f
+            )
+            drawLine(
             start = Offset(x = 10f, y = size.height - 55f),
             end = Offset(x = 60f, y = size.height - 105f),
             color = Color.Gray,
             strokeWidth = 2f
-        )
-        drawLine(
-            start = Offset(x = 60f, y = size.height - 55f),
-            end = Offset(x = 10f, y = size.height - 105f),
-            color = Color.Gray,
-            strokeWidth = 2f
-        )
-
-        drawLine(
-            start = Offset(x = 10f, y = size.height - 50f),
-            end = Offset(x = size.width - 10f, y = size.height - 50f),
-            color = Color.Gray,
-            strokeWidth = 2f
-        )
-
-        drawIntoCanvas { canvas ->
-            val paint = Paint().apply {
-                color = android.graphics.Color.GRAY
-                textSize = 30f
-            }
-            canvas.nativeCanvas.drawText(
-                "$firstName $lastName",
-                10f,
-                size.height - 10f,
-                paint
             )
+            drawLine(
+                start = Offset(x = 60f, y = size.height - 55f),
+                end = Offset(x = 10f, y = size.height - 105f),
+                color = Color.Gray,
+                strokeWidth = 2f
+            )
+
+            drawIntoCanvas { canvas ->
+                val paint = Paint().apply {
+                    color = android.graphics.Color.GRAY
+                    textSize = 30f
+                }
+                canvas.nativeCanvas.drawText(
+                    "$firstName $lastName",
+                    10f,
+                    size.height - 10f,
+                    paint
+                )
+            }
         }
     }
 }
@@ -124,15 +194,13 @@ internal fun SignatureCanvas(
 @Preview
 @Composable
 private fun SignatureCanvasPreview() {
-    val paths = remember { mutableStateListOf(Path()) }
     val firstName = remember { mutableStateOf("First Name") }
     val lastName = remember { mutableStateOf("Last Name") }
-    paths.add(Path())
 
     SignatureCanvas(
-        paths = paths,
         firstName = firstName.value,
         lastName = lastName.value,
-        onPathAdd = { paths.add(it) }
+        onPathAdd = {},
+        onViewCreated = {}
     )
 }

--- a/modules/onboarding/src/test/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentViewModelTest.kt
+++ b/modules/onboarding/src/test/kotlin/edu/stanford/spezi/modules/onboarding/consent/ConsentViewModelTest.kt
@@ -1,6 +1,7 @@
 package edu.stanford.spezi.modules.onboarding.consent
 
-import androidx.compose.ui.graphics.Path
+import androidx.ink.authoring.InProgressStrokeId
+import androidx.ink.strokes.Stroke
 import com.google.common.truth.Truth.assertThat
 import edu.stanford.spezi.modules.account.manager.UserSessionManager
 import edu.stanford.spezi.modules.testing.CoroutineTestRule
@@ -39,6 +40,16 @@ class ConsentViewModelTest {
         every { markdownParser.parse(any()) } returns emptyList()
     }
 
+    private fun createPath(): Map<InProgressStrokeId, Stroke> {
+        val mockStrokeId1 = mockk<InProgressStrokeId>()
+        val mockStroke1 = mockk<Stroke>()
+
+        val mockStrokeMap = mapOf(
+            mockStrokeId1 to mockStroke1,
+        )
+        return mockStrokeMap
+    }
+
     @Test
     fun `it should update firstName on TextFieldUpdate action correctly`() = runTestUnconfined {
         // Given
@@ -71,7 +82,7 @@ class ConsentViewModelTest {
     @Test
     fun `it should handle AddPath action correctly`() = runTestUnconfined {
         // Given
-        val action = ConsentAction.AddPath(Path())
+        val action = ConsentAction.AddPath(createPath())
 
         // When
         viewModel.onAction(action)
@@ -84,8 +95,22 @@ class ConsentViewModelTest {
     @Test
     fun `it should handle Undo action correctly`() = runTestUnconfined {
         // Given
-        viewModel.onAction(ConsentAction.AddPath(Path()))
-        val action = ConsentAction.Undo
+        viewModel.onAction(ConsentAction.AddPath(createPath()))
+        val action = ConsentAction.UndoPath
+
+        // When
+        viewModel.onAction(action)
+
+        // Then
+        val uiState = viewModel.uiState.first()
+        assertThat(uiState.paths.size).isEqualTo(0)
+    }
+
+    @Test
+    fun `it should handle Clear action correctly`() = runTestUnconfined {
+        // Given
+        viewModel.onAction(ConsentAction.AddPath(createPath()))
+        val action = ConsentAction.ClearPath
 
         // When
         viewModel.onAction(action)


### PR DESCRIPTION
# *Replace Signature Canvas with new INK Api*


## :recycle: Current situation & Problem
[Related Issue](https://github.com/StanfordSpezi/SpeziKt/issues/127)
> The current consent form uses a basic canvas for signature input, which works great but still could provide a smoother user experience with more advanced features.

>Upgrade the signature feature to utilize the newly introduced Ink API from October 24, which offers better handwriting and ink capture, improving precision and usability. Relevant documentation:

## :gear: Release Notes
- Replaced the custom Canvas implementation with the AndroidX Ink API for improved reliability and native stroke support.
- Implemented an Undo Stroke feature, as the previous implementation was non-functional during testing.
- Verified that the generated PDF output remains compatible with the new Ink-based stroke format.
- Upgraded the project to `Gradle 8.1.1` and `SDK 35` to meet the requirements of the Ink API.
- Note: The `ConsentScreen` is currently not wired into the app's navigation. For testing purposes, consider replacing the onboarding screen in `MainActivity` with:

  ```kotlin
  // Replace this
  composable<Routes.OnboardingScreen> {
      OnboardingScreen()
  }

  // With this
  composable<Routes.OnboardingScreen> {
      ConsentScreen()
  }

## :books: Documentation
- Modified the UiState paths variable to `List<Pair<InProgressStrokeId, Stroke>>`
  - `ID` is needed to remove the last stroke
  - `Stroke` is needed for the rendering of the PDF


## :white_check_mark: Testing
- Verified that existing UiState unit tests continue to pass, while adpating where needed.
- Performed manual testing:
  - Signature input works consistently across multiple invocations of the canvas.
  - Rapid input is handled correctly. 
    - ⚠️ In rare cases, strokes may be removed out of order. This is due to the Ink API providing an unordered Map in its update handler with all the Strokes newly added. If multiple values are contained, no order between them can be determined. This should not happen in normal use cases.

## 📹: Demo

https://github.com/user-attachments/assets/f1434b97-c512-43e1-bfd9-8ac1365e86fa

### Generated PDF
<img width="1024" alt="image" src="https://github.com/user-attachments/assets/8bcc69cf-f2cb-4383-8132-8a2c23688337" />


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
